### PR TITLE
Use more parallelism in compilation in CI testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ def cmake_build(Map conf=[:]){
         """
     def setup_cmd = conf.get("setup_cmd", "${cmake_envs} cmake ${setup_args}   .. ")
     // reduce parallelism when compiling, clang uses too much memory
-    def build_cmd = conf.get("build_cmd", "${build_envs} dumb-init make  -j\$(( \$(nproc) / 5 )) ${config_targets}")
+    def build_cmd = conf.get("build_cmd", "${build_envs} dumb-init make  -j\$(( \$(nproc) / 1 )) ${config_targets}")
     def execute_cmd = conf.get("execute_cmd", "")
 
     def cmd = conf.get("cmd", """


### PR DESCRIPTION
Previously, compilation parallelism is reduced in CI test, because clang use too much RAM, resulting in CI failure when building CK.

CI has been update to ROCm5.0 in a previous PR, now clang does use that much RAM. Therefore, this PR increase compilation parallelism