### PR TITLE
Change __launch_bounds__ "min block per CU" to 1

### DIFF
--- a/example/01_gemm/README.md
+++ b/example/01_gemm/README.md
@@ -1,4 +1,4 @@
-# Instructions for ```gemm_xdl``` Example
+# Instructions
 
 ## Docker script
 ```bash
@@ -13,7 +13,7 @@ rocm/tensorflow:rocm4.3.1-tf2.6-dev                                          \
 /bin/bash
 ```
 
-## Build ```gemm_xdl```
+## Build Example
 ```bash
 mkdir build && cd build
 ```
@@ -30,15 +30,15 @@ cmake                                                                  \
 ```
 
 ```bash
- make -j gemm_xdl
+ make -j example_gemm_xdl_fp16
 ```
 
-## Run ```gemm_xdl```
+## Run Example
 ```bash
 #arg1: verification (0=no, 1=yes)
 #arg2: initialization (0=no init, 1=integer value, 2=decimal value)
 #arg3: run kernel # of times (>1)
-./example/gemm_xdl 0 1 5
+./bin/example_gemm_xdl_fp16 0 1 5
 ```
 
 Result (MI100 @ 1087Mhz, 133.5TFlops peak FP16)

--- a/example/05_conv2d_fwd/README.md
+++ b/example/05_conv2d_fwd/README.md
@@ -1,4 +1,4 @@
-# Instructions for ```conv2d_fwd_xdl``` Example
+# Instructions
 
 ## Docker script
 ```bash
@@ -13,7 +13,7 @@ rocm/tensorflow:rocm4.3.1-tf2.6-dev                                          \
 /bin/bash
 ```
 
-## Build ```conv2d_fwd_xdl```
+## Build Example
 ```bash
 mkdir build && cd build
 ```
@@ -30,16 +30,16 @@ cmake                                                                  \
 ```
 
 ```bash
- make -j conv2d_fwd_xdl
+ make -j example_conv2d_fwd_xdl_fp16
 ```
 
-## Run ```conv2d_fwd_xdl```
+## Run Example
 ```bash
 #arg1: verification (0=no, 1=yes)
 #arg2: initialization (0=no init, 1=integer value, 2=decimal value)
 #arg3: run kernel # of times (>1)
 #arg4 to 18: N, K, C, Y, X, Hi, Wi, Sy, Sx, Dy, Dx, LeftPy, LeftPx, RightPy, RightPx
-./example/conv2d_fwd_xdl 0 1 5
+./bin/example_conv2d_fwd_xdl_fp16 0 1 5
 ```
 
 Result (MI100 @ 1087Mhz, 133.5TFlops peak FP16)

--- a/include/ck/config.hpp
+++ b/include/ck/config.hpp
@@ -21,7 +21,7 @@
 
 #ifdef CK_USE_LAUNCH_BOUNDS
 #define CK_MAX_THREAD_PER_BLOCK 256
-#define CK_MIN_BLOCK_PER_CU 2
+#define CK_MIN_BLOCK_PER_CU 1
 #endif
 
 // GPU-specific parameters


### PR DESCRIPTION
Change __launch_bounds__ "min block per CU" from 2 to 1.

Using value 2 trigger some compiler behavior on rocm5.0 that result in worse performance. Changing it to 1 recover some of the performance back
https://ontrack-internal.amd.com/browse/SWDEV-325335