### PR TITLE
Test: Use single thread for tensor init

### DIFF
--- a/example/12_reduce/reduce_blockwise.cpp
+++ b/example/12_reduce/reduce_blockwise.cpp
@@ -261,7 +261,7 @@ int main(int argc, char* argv[])
     float alpha = args.scales[0];
     float beta  = args.scales[1];
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     if(args.do_verification)
     {

--- a/library/include/ck/library/host_tensor/host_reduction.hpp
+++ b/library/include/ck/library/host_tensor/host_reduction.hpp
@@ -277,7 +277,7 @@ struct ReductionHost
                 out_indices[dst_offset] = accuIndex;
             };
 
-            std::size_t num_thread = std::thread::hardware_concurrency();
+            std::size_t num_thread = 1;
             std::size_t work_per_thread =
                 (invariant_dim_indexes.size() + num_thread - 1) / num_thread;
 
@@ -374,7 +374,7 @@ struct ReductionHost
                 out_data[dst_offset] = type_convert<OutDataType>(accuVal);
             };
 
-            std::size_t num_thread = std::thread::hardware_concurrency();
+            std::size_t num_thread = 1;
             std::size_t work_per_thread =
                 (invariant_dim_indexes.size() + num_thread - 1) / num_thread;
 

--- a/library/include/ck/library/host_tensor/host_tensor.hpp
+++ b/library/include/ck/library/host_tensor/host_tensor.hpp
@@ -163,7 +163,7 @@ struct ParallelTensorFunctor
         return indices;
     }
 
-    void operator()(std::size_t num_thread = std::thread::hardware_concurrency()) const
+    void operator()(std::size_t num_thread = 1) const
     {
         std::size_t work_per_thread = (mN1d + num_thread - 1) / num_thread;
 
@@ -213,7 +213,7 @@ struct Tensor
     Tensor(const HostTensorDescriptor& desc) : mDesc(desc), mData(mDesc.GetElementSpace()) {}
 
     template <typename G>
-    void GenerateTensorValue(G g, std::size_t num_thread = std::thread::hardware_concurrency())
+    void GenerateTensorValue(G g, std::size_t num_thread = 1)
     {
         switch(mDesc.GetNumOfDimension())
         {

--- a/library/src/obselete_driver_offline/conv_add_fwd_driver_offline_nchwc.cpp
+++ b/library/src/obselete_driver_offline/conv_add_fwd_driver_offline_nchwc.cpp
@@ -302,7 +302,7 @@ int main(int argc, char* argv[])
     print_array("ConvStrides", make_tuple(conv_stride_h, conv_stride_w));
     print_array("ConvDilations", make_tuple(conv_dilation_h, conv_dilation_w));
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/library/src/obselete_driver_offline/conv_bwd_driver_offline.cpp
+++ b/library/src/obselete_driver_offline/conv_bwd_driver_offline.cpp
@@ -317,7 +317,7 @@ int main(int argc, char* argv[])
     print_array("ConvStrides", make_tuple(conv_stride_h, conv_stride_w));
     print_array("ConvDilations", make_tuple(conv_dilation_h, conv_dilation_w));
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/library/src/obselete_driver_offline/conv_fwd_driver_offline.cpp
+++ b/library/src/obselete_driver_offline/conv_fwd_driver_offline.cpp
@@ -319,7 +319,7 @@ int main(int argc, char* argv[])
     print_array("ConvStrides", make_tuple(conv_stride_h, conv_stride_w));
     print_array("ConvDilations", make_tuple(conv_dilation_h, conv_dilation_w));
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/library/src/obselete_driver_offline/conv_fwd_driver_offline_nchwc.cpp
+++ b/library/src/obselete_driver_offline/conv_fwd_driver_offline_nchwc.cpp
@@ -282,7 +282,7 @@ int main(int argc, char* argv[])
     print_array("ConvStrides", make_tuple(conv_stride_h, conv_stride_w));
     print_array("ConvDilations", make_tuple(conv_dilation_h, conv_dilation_w));
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/library/src/obselete_driver_offline/conv_maxpool_fwd_driver_offline_nchwc.cpp
+++ b/library/src/obselete_driver_offline/conv_maxpool_fwd_driver_offline_nchwc.cpp
@@ -300,7 +300,7 @@ int main(int argc, char* argv[])
     print_array("ConvStrides", make_tuple(conv_stride_h, conv_stride_w));
     print_array("ConvDilations", make_tuple(conv_dilation_h, conv_dilation_w));
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/library/src/obselete_driver_offline/conv_wrw_driver_offline.cpp
+++ b/library/src/obselete_driver_offline/conv_wrw_driver_offline.cpp
@@ -289,7 +289,7 @@ int main(int argc, char* argv[])
     print_array("ConvStrides", make_tuple(conv_stride_h, conv_stride_w));
     print_array("ConvDilations", make_tuple(conv_dilation_h, conv_dilation_w));
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/library/src/obselete_driver_offline/gemm_driver_offline.cpp
+++ b/library/src/obselete_driver_offline/gemm_driver_offline.cpp
@@ -313,7 +313,7 @@ int main(int argc, char* argv[])
     ostream_HostTensorDescriptor(b.mDesc, std::cout << "b: ");
     ostream_HostTensorDescriptor(c_host.mDesc, std::cout << "c: ");
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/profiler/include/profile_batched_gemm_impl.hpp
+++ b/profiler/include/profile_batched_gemm_impl.hpp
@@ -93,7 +93,7 @@ void profile_batched_gemm_impl(int do_verification,
     std::cout << "b_g_k_n: " << b_g_k_n.mDesc << std::endl;
     std::cout << "c_g_m_n: " << c_g_m_n_host_result.mDesc << std::endl;
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
     switch(init_method)
     {
     case 0: break;

--- a/profiler/include/profile_gemm_bias_2d_impl.hpp
+++ b/profiler/include/profile_gemm_bias_2d_impl.hpp
@@ -98,7 +98,7 @@ void profile_gemm_bias_2d_impl(int do_verification,
     std::cout << "c0_m_n: " << c0_m_n.mDesc << std::endl;
     std::cout << "c_m_n: " << c_m_n_host_result.mDesc << std::endl;
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
     switch(init_method)
     {
     case 0: break;

--- a/profiler/include/profile_gemm_bias_relu_impl.hpp
+++ b/profiler/include/profile_gemm_bias_relu_impl.hpp
@@ -83,7 +83,7 @@ void profile_gemm_bias_relu_impl(int do_verification,
     std::cout << "c_m_n: " << c_m_n_host_result.mDesc << std::endl;
     std::cout << "c0_n: " << c0_n.mDesc << std::endl;
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
     switch(init_method)
     {
     case 0: break;

--- a/profiler/include/profile_gemm_impl.hpp
+++ b/profiler/include/profile_gemm_impl.hpp
@@ -120,7 +120,7 @@ void profile_gemm_impl(int do_verification,
     std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
     std::cout << "c_m_n: " << c_m_n_device_result.mDesc << std::endl;
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
     switch(init_method)
     {
     case 0: break;
@@ -408,6 +408,10 @@ void profile_gemm_impl(int do_verification,
 
         if(gemm_ptr->IsSupportedArgument(argument_ptr.get()))
         {
+            // re-init C to zero before profiling next kernel
+            c_m_n_device_result.GenerateTensorValue(GeneratorTensor_0<CDataType>{}, num_thread);
+            c_device_buf.ToDevice(c_m_n_device_result.mData.data());
+
             std::string gemm_name = gemm_ptr->GetTypeString();
 
             float ave_time = invoker_ptr->Run(argument_ptr.get(), nrepeat);

--- a/profiler/include/profile_gemm_reduce_impl.hpp
+++ b/profiler/include/profile_gemm_reduce_impl.hpp
@@ -98,7 +98,7 @@ bool profile_gemm_reduce_impl(int do_verification,
     std::cout << "d0_m: " << d0_m_host_result.mDesc << std::endl;
     std::cout << "d1_m: " << d1_m_host_result.mDesc << std::endl;
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
     switch(init_method)
     {
     case 0: break;

--- a/profiler/include/profile_grouped_gemm_impl.hpp
+++ b/profiler/include/profile_grouped_gemm_impl.hpp
@@ -95,7 +95,7 @@ void profile_grouped_gemm_impl(int do_verification,
                   << "]:" << b_k_n[i].mDesc << ", c_m_n_device_results[" << i
                   << "]:" << c_m_n_device_results[i].mDesc << std::endl;
 
-        std::size_t num_thread = std::thread::hardware_concurrency();
+        std::size_t num_thread = 1;
         switch(init_method)
         {
         case 0: break;

--- a/profiler/include/profile_reduce_impl.hpp
+++ b/profiler/include/profile_reduce_impl.hpp
@@ -242,7 +242,7 @@ void profile_reduce_impl_impl(bool do_verification,
         size_t invariant_total_length = out.mDesc.GetElementSize();
         size_t reduce_total_length    = in.mDesc.GetElementSize() / invariant_total_length;
 
-        std::size_t num_thread = std::thread::hardware_concurrency();
+        std::size_t num_thread = 1;
 
         if(do_verification)
         {

--- a/test/gemm_split_k/gemm_split_k.cpp
+++ b/test/gemm_split_k/gemm_split_k.cpp
@@ -120,7 +120,7 @@ int test_gemm(const gemmArgs& args)
         f_host_tensor_descriptor(args.M, args.N, args.StrideC, c_row_major));
 
     // init data
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
     a_m_k.GenerateTensorValue(GeneratorTensor_2<float>{-5, 5}, num_thread);
     b_k_n.GenerateTensorValue(GeneratorTensor_2<float>{-5, 5}, num_thread);
     // set zero to c_device_buf

--- a/test/reduce/reduce_no_index.cpp
+++ b/test/reduce/reduce_no_index.cpp
@@ -101,7 +101,7 @@ bool test_reduce_no_index_impl(int init_method,
     size_t invariant_total_length = out.mDesc.GetElementSize();
     size_t reduce_total_length    = in.mDesc.GetElementSize() / invariant_total_length;
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {

--- a/test/reduce/reduce_with_index.cpp
+++ b/test/reduce/reduce_with_index.cpp
@@ -99,7 +99,7 @@ bool test_reduce_with_index_impl(int init_method,
     size_t invariant_total_length = out.mDesc.GetElementSize();
     size_t reduce_total_length    = in.mDesc.GetElementSize() / invariant_total_length;
 
-    std::size_t num_thread = std::thread::hardware_concurrency();
+    std::size_t num_thread = 1;
 
     switch(init_method)
     {


### PR DESCRIPTION
Several EPYC nodes I have access to experience massive slowdown using multi-threaded tensor initialization. Reverting to single-threaded and see if it improves CI time.

### Update (03/31/2022):
CI reports total test time of single vs multithreaded tensor initial value generator: 512.33 sec vs 1025.49 sec. So it's definitely cutting down the test time.

CI test log using single-threaded tensor initialization  (http://micimaster.amd.com/blue/organizations/jenkins/MLLibs%2Fcomposable_kernel/detail/single-thd-tensor-init/1/pipeline/156/)
```
[2022-03-30T12:01:56.733Z] Test project /var/jenkins/workspace/le_kernel_single-thd-tensor-init/build/test
[2022-03-30T12:01:56.733Z]       Start  1: test_magic_number_division
[2022-03-30T12:01:56.733Z]       Start  2: test_space_filling_curve
[2022-03-30T12:01:56.733Z]       Start  3: test_conv_util
[2022-03-30T12:01:56.733Z]       Start  4: test_reference_conv_fwd
[2022-03-30T12:01:56.733Z]  1/17 Test  #3: test_conv_util ...................   Passed    0.05 sec
[2022-03-30T12:01:56.733Z]       Start  5: test_gemm_fp32
[2022-03-30T12:01:56.733Z]  2/17 Test  #2: test_space_filling_curve .........   Passed    0.05 sec
[2022-03-30T12:01:56.733Z]       Start  6: test_gemm_fp16
[2022-03-30T12:01:56.733Z]  3/17 Test  #4: test_reference_conv_fwd ..........   Passed    0.07 sec
[2022-03-30T12:01:56.733Z]       Start  7: test_gemm_bf16
[2022-03-30T12:02:00.135Z]  4/17 Test  #1: test_magic_number_division .......   Passed    3.24 sec
[2022-03-30T12:02:00.135Z]       Start  8: test_gemm_int8
[2022-03-30T12:02:46.842Z]  5/17 Test  #8: test_gemm_int8 ...................   Passed   43.23 sec
[2022-03-30T12:02:46.842Z]       Start  9: test_gemm_split_k
[2022-03-30T12:02:46.842Z]  6/17 Test  #9: test_gemm_split_k ................   Passed    0.15 sec
[2022-03-30T12:02:46.842Z]       Start 10: test_gemm_reduce_fp16
[2022-03-30T12:02:46.842Z]  7/17 Test #10: test_gemm_reduce_fp16 ............   Passed    1.80 sec
[2022-03-30T12:02:46.842Z]       Start 11: test_batched_gemm_fp16
[2022-03-30T12:03:01.741Z]  8/17 Test  #7: test_gemm_bf16 ...................   Passed   62.40 sec
[2022-03-30T12:03:01.741Z]       Start 12: test_grouped_gemm_fp16
[2022-03-30T12:03:58.005Z]  9/17 Test #11: test_batched_gemm_fp16 ...........   Passed   72.09 sec
[2022-03-30T12:03:58.005Z]       Start 13: test_conv1d_fwd
[2022-03-30T12:04:01.300Z] 10/17 Test  #5: test_gemm_fp32 ...................   Passed  124.23 sec
[2022-03-30T12:04:01.300Z]       Start 14: test_conv2d_fwd
[2022-03-30T12:04:05.503Z] 11/17 Test #13: test_conv1d_fwd ..................   Passed    8.16 sec
[2022-03-30T12:04:05.503Z]       Start 15: test_conv3d_fwd
[2022-03-30T12:05:42.001Z] 12/17 Test #12: test_grouped_gemm_fp16 ...........   Passed  154.06 sec
[2022-03-30T12:05:42.001Z]       Start 16: test_reduce_no_index
[2022-03-30T12:05:56.894Z] 13/17 Test #16: test_reduce_no_index .............   Passed   21.37 sec
[2022-03-30T12:05:56.894Z]       Start 17: test_reduce_with_index
[2022-03-30T12:06:09.113Z] 14/17 Test  #6: test_gemm_fp16 ...................   Passed  252.32 sec
[2022-03-30T12:06:17.241Z] 15/17 Test #17: test_reduce_with_index ...........   Passed   21.25 sec
[2022-03-30T12:08:38.943Z] 16/17 Test #15: test_conv3d_fwd ..................   Passed  262.47 sec
[2022-03-30T12:10:30.447Z] 17/17 Test #14: test_conv2d_fwd ..................   Passed  388.04 sec
[2022-03-30T12:10:30.447Z] 
[2022-03-30T12:10:30.447Z] 100% tests passed, 0 tests failed out of 17
[2022-03-30T12:10:30.447Z] 
[2022-03-30T12:10:30.447Z] Total Test time (real) = 512.33 sec
```

CI test log using multi-threaded tensor initialization (http://micimaster.amd.com/blue/organizations/jenkins/MLLibs%2Fcomposable_kernel/detail/develop/36/pipeline)
```
[2022-03-30T00:18:08.150Z] Test project /var/jenkins/workspace/MLLibs_composable_kernel_develop/build/test
[2022-03-30T00:18:08.150Z]       Start  1: test_magic_number_division
[2022-03-30T00:18:08.150Z]       Start  2: test_space_filling_curve
[2022-03-30T00:18:08.150Z]       Start  3: test_conv_util
[2022-03-30T00:18:08.150Z]       Start  4: test_reference_conv_fwd
[2022-03-30T00:18:08.150Z]  1/17 Test  #3: test_conv_util ...................   Passed    0.03 sec
[2022-03-30T00:18:08.150Z]       Start  5: test_gemm_fp32
[2022-03-30T00:18:08.150Z]  2/17 Test  #2: test_space_filling_curve .........   Passed    0.03 sec
[2022-03-30T00:18:08.150Z]       Start  6: test_gemm_fp16
[2022-03-30T00:18:08.150Z]  3/17 Test  #4: test_reference_conv_fwd ..........   Passed    0.04 sec
[2022-03-30T00:18:08.150Z]       Start  7: test_gemm_bf16
[2022-03-30T00:18:10.081Z]  4/17 Test  #1: test_magic_number_division .......   Passed    3.97 sec
[2022-03-30T00:18:10.081Z]       Start  8: test_gemm_int8
[2022-03-30T00:20:01.598Z]  5/17 Test  #8: test_gemm_int8 ...................   Passed  110.32 sec
[2022-03-30T00:20:01.598Z]       Start  9: test_gemm_split_k
[2022-03-30T00:20:01.598Z]  6/17 Test  #9: test_gemm_split_k ................   Passed    0.07 sec
[2022-03-30T00:20:01.598Z]       Start 10: test_gemm_reduce_fp16
[2022-03-30T00:20:01.857Z]  7/17 Test #10: test_gemm_reduce_fp16 ............   Passed    1.64 sec
[2022-03-30T00:20:01.857Z]       Start 11: test_batched_gemm_fp16
[2022-03-30T00:20:40.636Z]  8/17 Test  #7: test_gemm_bf16 ...................   Passed  153.52 sec
[2022-03-30T00:20:40.636Z]       Start 12: test_grouped_gemm_fp16
[2022-03-30T00:22:47.123Z]  9/17 Test #11: test_batched_gemm_fp16 ...........   Passed  157.66 sec
[2022-03-30T00:22:47.123Z]       Start 13: test_conv1d_fwd
[2022-03-30T00:22:53.702Z] 10/17 Test #13: test_conv1d_fwd ..................   Passed   13.35 sec
[2022-03-30T00:22:53.702Z]       Start 14: test_conv2d_fwd
[2022-03-30T00:23:11.804Z] 11/17 Test  #5: test_gemm_fp32 ...................   Passed  303.27 sec
[2022-03-30T00:23:11.804Z]       Start 15: test_conv3d_fwd
[2022-03-30T00:26:48.348Z] 12/17 Test #12: test_grouped_gemm_fp16 ...........   Passed  360.70 sec
[2022-03-30T00:26:48.348Z]       Start 16: test_reduce_no_index
[2022-03-30T00:27:10.297Z] 13/17 Test #16: test_reduce_no_index .............   Passed   29.82 sec
[2022-03-30T00:27:10.297Z]       Start 17: test_reduce_with_index
[2022-03-30T00:27:36.864Z] 14/17 Test  #6: test_gemm_fp16 ...................   Passed  570.25 sec
[2022-03-30T00:27:46.846Z] 15/17 Test #17: test_reduce_with_index ...........   Passed   36.14 sec
[2022-03-30T00:31:38.399Z] 16/17 Test #15: test_conv3d_fwd ..................   Passed  495.45 sec
[2022-03-30T00:35:15.001Z] 17/17 Test #14: test_conv2d_fwd ..................   Passed  738.48 sec
[2022-03-30T00:35:15.002Z] 
[2022-03-30T00:35:15.002Z] 100% tests passed, 0 tests failed out of 17
[2022-03-30T00:35:15.002Z] 
[2022-03-30T00:35:15.002Z] Total Test time (real) = 1025.49 sec
```










































































