### PR TITLE
Manual control of MAC cluster for improved interwave performance

### DIFF
--- a/include/ck/config.hpp
+++ b/include/ck/config.hpp
@@ -109,6 +109,10 @@
 // experimental feature: use __builtin_memcpy instead of union to do bit_cast
 #define CK_EXPERIMENTAL_USE_MEMCPY_FOR_BIT_CAST 1
 
+// experimental feature: optimize for inter-wave scheduling policy
+#define CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING 0
+#define CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING_MAC_CLUSTERS 1
+
 // hack: have underlying assumption that need to be satsified, otherwise it's a bug
 // hack for forcing register to keep idx_diff_low_const in SGPR. idx_diff_low_const must be
 // thread-invariant, otherwise it's a bug

--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
+++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
@@ -7,6 +7,21 @@
 
 namespace ck {
 
+enum struct LoopScheduler
+{
+    Default,
+    Interwave,
+};
+
+constexpr LoopScheduler make_default_loop_scheduler()
+{
+#if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
+    return LoopScheduler::Interwave;
+#else
+    return LoopScheduler::Default;
+#endif // if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
+}
+
 template <index_t BlockSize,
           typename FloatAB,
           typename FloatAcc,

--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
+++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
@@ -287,7 +287,7 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
             // NOTE: sync thread at the start of each MAC cluster except for the first MAC cluster
             // we want waves in a workgroup in sync to prevent waves from other workgroups hijacking
             // MAC resource
-            if constexpr(int(k) != 0 || KPerInnerLoop == KPerThread)
+            if constexpr(k.value != 0 || KPerInnerLoop == KPerThread)
             {
                 asm volatile("s_barrier" ::);
                 __builtin_amdgcn_sched_barrier();
@@ -318,9 +318,9 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
                         // moved here B) reduce VMEM FIFO congestion by applying small delays to
                         // different wavefronts It is performed near the end of MAC cluster to
                         // minimize lgkmcnt penalty
-                        if constexpr(int(k) == KPerThread - KPerInnerLoop &&
-                                     int(k_) == KPerInnerLoop - KPack && int(m0) == MRepeat - 1 &&
-                                     int(n0) == NRepeat - 1)
+                        if constexpr(k.value == KPerThread - KPerInnerLoop &&
+                                     k_.value == KPerInnerLoop - KPack && m0.value == MRepeat - 1 &&
+                                     n0.value == NRepeat - 1)
                         {
                             __builtin_amdgcn_sched_barrier();
                             block_sync_lds();
@@ -333,7 +333,7 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
                             a_thread_vec.template AsType<mfma_input_type>(),
                             b_thread_vec.template AsType<mfma_input_type>(),
                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
-                        if constexpr(int(k_) == 0 && int(m0) == 0 && int(n0) == 0)
+                        if constexpr(k_.value == 0 && m0.value == 0 && n0.value == 0)
                         {
                             __builtin_amdgcn_sched_barrier();
                             __builtin_amdgcn_s_setprio(1);

--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
+++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
@@ -250,9 +250,8 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
 
 #if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
 
-    static constexpr index_t KPerInnerLoop = math::max(
-        KPerThread / CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING_MAC_CLUSTERS,
-        KPack);
+    static constexpr index_t KPerInnerLoop =
+        math::max(KPerThread / CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING_MAC_CLUSTERS, KPack);
 
     // 2-wave optimized blockwise gemm
     template <typename ABlockBuffer, typename BBlockBuffer, typename CThreadBuffer>
@@ -319,8 +318,9 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
                         // moved here B) reduce VMEM FIFO congestion by applying small delays to
                         // different wavefronts It is performed near the end of MAC cluster to
                         // minimize lgkmcnt penalty
-                        if constexpr(int(k) == KPerThread - KPerInnerLoop && int(k_) == KPerInnerLoop - KPack &&
-                                     int(m0) == MRepeat - 1 && int(n0) == NRepeat - 1)
+                        if constexpr(int(k) == KPerThread - KPerInnerLoop &&
+                                     int(k_) == KPerInnerLoop - KPack && int(m0) == MRepeat - 1 &&
+                                     int(n0) == NRepeat - 1)
                         {
                             __builtin_amdgcn_sched_barrier();
                             block_sync_lds();
@@ -350,12 +350,12 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
 
     private:
     // A[M0, M1, M2, KPerInnerLoop]
-    static constexpr auto a_thread_desc_ =
-        make_naive_tensor_descriptor_packed(make_tuple(Number<MRepeat>{}, I1, I1, Number<KPerInnerLoop>{}));
+    static constexpr auto a_thread_desc_ = make_naive_tensor_descriptor_packed(
+        make_tuple(Number<MRepeat>{}, I1, I1, Number<KPerInnerLoop>{}));
 
     // B[N0, N1, N2, KPerInnerLoop]
-    static constexpr auto b_thread_desc_ =
-        make_naive_tensor_descriptor_packed(make_tuple(Number<NRepeat>{}, I1, I1, Number<KPerInnerLoop>{}));
+    static constexpr auto b_thread_desc_ = make_naive_tensor_descriptor_packed(
+        make_tuple(Number<NRepeat>{}, I1, I1, Number<KPerInnerLoop>{}));
 
     using AThreadCopy = ThreadwiseTensorSliceTransfer_v4<FloatAB,
                                                          FloatAB,
@@ -377,7 +377,7 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
                                                          B_K1,
                                                          B_K1>;
 
-#else  // #if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
+#else // #if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
 
     template <typename ABlockBuffer, typename BBlockBuffer, typename CThreadBuffer>
     __device__ void Run(const ABlockBuffer& a_block_buf,
@@ -467,7 +467,6 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
     // C[M, N, NumRegXdlops]
     static constexpr auto c_thread_desc_ = make_naive_tensor_descriptor_packed(
         make_tuple(Number<MRepeat>{}, Number<NRepeat>{}, xdlops_gemm.GetRegSizePerXdlops()));
-
 
     AThreadCopy a_thread_copy_{CalculateAThreadOriginDataIndex()};
     BThreadCopy b_thread_copy_{CalculateBThreadOriginDataIndex()};

--- a/include/ck/tensor_operation/gpu/device/device_batched_gemm_reduce_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_batched_gemm_reduce_xdl_cshuffle.hpp
@@ -106,6 +106,9 @@ __global__ void
 #endif // end of if defined (defined(__gfx908__) || defined(__gfx90a__))
 }
 
+// Note: inter-wave loop scheduler is rolled out to c-shuffle version first. Becuase non c-shuffle
+// version currently has compiler issues with register spill which further causes validation
+// failures.
 template <typename ALayout,
           typename BLayout,
           typename CLayout,
@@ -154,7 +157,8 @@ template <typename ALayout,
           index_t CShuffleBlockTransferScalarPerVector_NPerBlock,
           typename CReduceThreadClusterLengths_MPerBlock_NPerBlock,
           index_t CReduceThreadLds2VGprCopySrcDstScalarPerVector_NPerBlock,
-          index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock>
+          index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock,
+          LoopScheduler LoopSched = make_default_loop_scheduler()>
 struct DeviceBatchedGemmReduce_Xdl_CShuffle : public DeviceGemmReduce<AElementwiseOperation,
                                                                       BElementwiseOperation,
                                                                       CElementwiseOperation,
@@ -600,7 +604,8 @@ struct DeviceBatchedGemmReduce_Xdl_CShuffle : public DeviceGemmReduce<AElementwi
         CShuffleBlockTransferScalarPerVector_NPerBlock,
         CReduceThreadClusterLengths_MPerBlock_NPerBlock,
         CReduceThreadLds2VGprCopySrcDstScalarPerVector_NPerBlock,
-        CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock>;
+        CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock,
+        LoopSched>;
 
     using Block2CTileMap = decltype(MakeBlock2CTileMap(1, CGridDesc_M_N{}, 1, 1));
 

--- a/include/ck/tensor_operation/gpu/device/device_gemm_reduce_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_gemm_reduce_xdl_cshuffle.hpp
@@ -66,7 +66,7 @@ template <typename ALayout,
           typename CReduceThreadClusterLengths_MPerBlock_NPerBlock,
           index_t CReduceThreadLds2VGprCopySrcDstScalarPerVector_NPerBlock,
           index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock,
-          LoopScheduler LoopSched = LoopScheduler::Interwave>
+          LoopScheduler LoopSched = make_default_loop_scheduler()>
 struct DeviceGemmReduce_Xdl_CShuffle : public DeviceGemmReduce<AElementwiseOperation,
                                                                BElementwiseOperation,
                                                                CElementwiseOperation,

--- a/include/ck/tensor_operation/gpu/device/device_gemm_reduce_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_gemm_reduce_xdl_cshuffle.hpp
@@ -15,7 +15,8 @@ namespace tensor_operation {
 namespace device {
 
 // Note: inter-wave loop scheduler is rolled out to c-shuffle version first. Becuase non c-shuffle
-// version currently has compiler issues with register spill which further causes validation failures.
+// version currently has compiler issues with register spill which further causes validation
+// failures.
 template <typename ALayout,
           typename BLayout,
           typename CLayout,

--- a/include/ck/tensor_operation/gpu/device/device_gemm_reduce_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_gemm_reduce_xdl_cshuffle.hpp
@@ -14,6 +14,8 @@ namespace ck {
 namespace tensor_operation {
 namespace device {
 
+// Note: inter-wave loop scheduler is rolled out to c-shuffle version first. Becuase non c-shuffle
+// version currently has compiler issues with register spill which further causes validation failures.
 template <typename ALayout,
           typename BLayout,
           typename CLayout,
@@ -62,7 +64,8 @@ template <typename ALayout,
           index_t CShuffleBlockTransferScalarPerVector_NPerBlock,
           typename CReduceThreadClusterLengths_MPerBlock_NPerBlock,
           index_t CReduceThreadLds2VGprCopySrcDstScalarPerVector_NPerBlock,
-          index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock>
+          index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock,
+          LoopScheduler LoopSched = LoopScheduler::Interwave>
 struct DeviceGemmReduce_Xdl_CShuffle : public DeviceGemmReduce<AElementwiseOperation,
                                                                BElementwiseOperation,
                                                                CElementwiseOperation,
@@ -422,7 +425,8 @@ struct DeviceGemmReduce_Xdl_CShuffle : public DeviceGemmReduce<AElementwiseOpera
         CShuffleBlockTransferScalarPerVector_NPerBlock,
         CReduceThreadClusterLengths_MPerBlock_NPerBlock,
         CReduceThreadLds2VGprCopySrcDstScalarPerVector_NPerBlock,
-        CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock>;
+        CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock,
+        LoopSched>;
 
     // Argument
     struct Argument : public BaseArgument

--- a/include/ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp
@@ -14,6 +14,8 @@ namespace ck {
 namespace tensor_operation {
 namespace device {
 
+// Note: inter-wave loop scheduler is rolled out to c-shuffle version first. Becuase non c-shuffle
+// version currently has compiler issues with register spill which further causes validation failures.
 template <typename ALayout,
           typename BLayout,
           typename CLayout,
@@ -54,7 +56,8 @@ template <typename ALayout,
           index_t CShuffleMXdlPerWavePerShuffle,
           index_t CShuffleNXdlPerWavePerShuffle,
           typename CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,
-          index_t CShuffleBlockTransferScalarPerVector_NPerBlock>
+          index_t CShuffleBlockTransferScalarPerVector_NPerBlock,
+          LoopScheduler LoopSched = LoopScheduler::Interwave>
 struct DeviceGemm_Xdl_CShuffle
     : public DeviceGemm<AElementwiseOperation, BElementwiseOperation, CElementwiseOperation>
 {
@@ -375,7 +378,8 @@ struct DeviceGemm_Xdl_CShuffle
         CShuffleMXdlPerWavePerShuffle,
         CShuffleNXdlPerWavePerShuffle,
         CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,
-        CShuffleBlockTransferScalarPerVector_NPerBlock>;
+        CShuffleBlockTransferScalarPerVector_NPerBlock,
+        LoopSched>;
 
     // Argument
     struct Argument : public BaseArgument

--- a/include/ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp
@@ -15,7 +15,8 @@ namespace tensor_operation {
 namespace device {
 
 // Note: inter-wave loop scheduler is rolled out to c-shuffle version first. Becuase non c-shuffle
-// version currently has compiler issues with register spill which further causes validation failures.
+// version currently has compiler issues with register spill which further causes validation
+// failures.
 template <typename ALayout,
           typename BLayout,
           typename CLayout,

--- a/include/ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp
@@ -58,7 +58,7 @@ template <typename ALayout,
           index_t CShuffleNXdlPerWavePerShuffle,
           typename CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,
           index_t CShuffleBlockTransferScalarPerVector_NPerBlock,
-          LoopScheduler LoopSched = LoopScheduler::Interwave>
+          LoopScheduler LoopSched = make_default_loop_scheduler()>
 struct DeviceGemm_Xdl_CShuffle
     : public DeviceGemm<AElementwiseOperation, BElementwiseOperation, CElementwiseOperation>
 {

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
@@ -79,7 +79,9 @@ struct GridwiseGemmPipeline_v1<1>
 
                 blockwise_gemm.Run(a_block_buf, b_block_buf, c_thread_buf);
 
+#if !CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
                 block_sync_lds();
+#endif // !CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
 
                 a_blockwise_copy.MoveSrcSliceWindow(a_grid_desc, a_block_copy_step);
                 b_blockwise_copy.MoveSrcSliceWindow(b_grid_desc, b_block_copy_step);

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
@@ -79,9 +79,7 @@ struct GridwiseGemmPipeline_v1<1>
 
                 blockwise_gemm.Run(a_block_buf, b_block_buf, c_thread_buf);
 
-#if !CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
                 block_sync_lds();
-#endif // !CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
 
                 a_blockwise_copy.MoveSrcSliceWindow(a_grid_desc, a_block_copy_step);
                 b_blockwise_copy.MoveSrcSliceWindow(b_grid_desc, b_block_copy_step);
@@ -249,5 +247,113 @@ struct GridwiseGemmPipeline_v1<2>
         }
     }
 };
+
+template <index_t NumPrefetch>
+struct GridwiseGemmPipelineInterwave_v1;
+
+template <>
+struct GridwiseGemmPipelineInterwave_v1<1>
+{
+    __host__ __device__ static constexpr bool IsSupported(index_t /* num_loop */) { return true; }
+
+    __host__ __device__ static constexpr bool CalculateHasMainLoop(index_t num_loop)
+    {
+        return num_loop > 1;
+    }
+
+    template <bool HasMainLoop,
+              typename AGridDesc,
+              typename ABlockDesc,
+              typename ABlockTransfer,
+              typename AGridBuffer,
+              typename ABlockBuffer,
+              typename ABlockTransferStep,
+              typename BGridDesc,
+              typename BBlockDesc,
+              typename BBlockTransfer,
+              typename BGridBuffer,
+              typename BBlockBuffer,
+              typename BBlockTransferStep,
+              typename BlockwiseGemm,
+              typename CThreadBuffer>
+    static __device__ void
+    Run(const AGridDesc& a_grid_desc,
+        const ABlockDesc& a_block_desc,
+        ABlockTransfer& a_blockwise_copy,
+        const AGridBuffer& a_grid_buf,
+        ABlockBuffer& a_block_buf,
+        const ABlockTransferStep& a_block_copy_step,
+        const BGridDesc& b_grid_desc,
+        const BBlockDesc& b_block_desc,
+        BBlockTransfer& b_blockwise_copy,
+        const BGridBuffer& b_grid_buf,
+        BBlockBuffer& b_block_buf,
+        const BBlockTransferStep& b_block_copy_step,
+        const BlockwiseGemm& blockwise_gemm,
+        CThreadBuffer& c_thread_buf,
+        index_t num_loop)
+    {
+        // preload data into LDS
+        a_blockwise_copy.RunRead(a_grid_desc, a_grid_buf);
+        b_blockwise_copy.RunRead(b_grid_desc, b_grid_buf);
+
+        a_blockwise_copy.MoveSrcSliceWindow(a_grid_desc, a_block_copy_step);
+        b_blockwise_copy.MoveSrcSliceWindow(b_grid_desc, b_block_copy_step);
+
+        // Initialize C
+        c_thread_buf.Clear();
+
+        a_blockwise_copy.RunWrite(a_block_desc, a_block_buf);
+        b_blockwise_copy.RunWrite(b_block_desc, b_block_buf);
+
+        // main body
+        if constexpr(HasMainLoop)
+        {
+            index_t i = 0;
+
+            do
+            {
+                a_blockwise_copy.RunRead(a_grid_desc, a_grid_buf);
+
+                block_sync_lds();
+
+                b_blockwise_copy.RunRead(b_grid_desc, b_grid_buf);
+
+                blockwise_gemm.Run(a_block_buf, b_block_buf, c_thread_buf);
+
+                // block_sync_lds(); // moved into blockwise_gemm
+
+                a_blockwise_copy.MoveSrcSliceWindow(a_grid_desc, a_block_copy_step);
+                b_blockwise_copy.MoveSrcSliceWindow(b_grid_desc, b_block_copy_step);
+
+                a_blockwise_copy.RunWrite(a_block_desc, a_block_buf);
+                b_blockwise_copy.RunWrite(b_block_desc, b_block_buf);
+
+                ++i;
+            } while(i < (num_loop - 1));
+        }
+
+        // tail
+        {
+            block_sync_lds();
+
+            blockwise_gemm.Run(a_block_buf, b_block_buf, c_thread_buf);
+        }
+    }
+};
+
+template <index_t NumPrefetch,
+          bool HasMainLoop>
+constexpr auto GridwiseGemmPipeline_v1_Selector()
+{
+    if constexpr(LoopSched == LoopScheduler::Default)
+    {
+        return GridwiseGemmPipeline_v1<NumPrefetch>{};
+    }
+    else if constexpr(LoopSched == LoopScheduler::Interwave)
+    {
+        return GridwiseGemmPipelineInterwave_v1<NumPrefetch>{};
+    }
+}
 
 } // namespace ck

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "common_header.hpp"
+#include "tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp"
 
 namespace ck {
 
@@ -341,8 +342,13 @@ struct GridwiseGemmPipelineInterwave_v1<1>
     }
 };
 
-template <index_t NumPrefetch,
-          bool HasMainLoop>
+// Note: 2 stage prefetch not optimized for inter-wave loop scheduler
+template <>
+struct GridwiseGemmPipelineInterwave_v1<2> : public GridwiseGemmPipeline_v1<2>
+{
+};
+
+template <index_t NumPrefetch, LoopScheduler LoopSched>
 constexpr auto GridwiseGemmPipeline_v1_Selector()
 {
     if constexpr(LoopSched == LoopScheduler::Default)

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v1.hpp
@@ -276,22 +276,21 @@ struct GridwiseGemmPipelineInterwave_v1<1>
               typename BBlockTransferStep,
               typename BlockwiseGemm,
               typename CThreadBuffer>
-    static __device__ void
-    Run(const AGridDesc& a_grid_desc,
-        const ABlockDesc& a_block_desc,
-        ABlockTransfer& a_blockwise_copy,
-        const AGridBuffer& a_grid_buf,
-        ABlockBuffer& a_block_buf,
-        const ABlockTransferStep& a_block_copy_step,
-        const BGridDesc& b_grid_desc,
-        const BBlockDesc& b_block_desc,
-        BBlockTransfer& b_blockwise_copy,
-        const BGridBuffer& b_grid_buf,
-        BBlockBuffer& b_block_buf,
-        const BBlockTransferStep& b_block_copy_step,
-        const BlockwiseGemm& blockwise_gemm,
-        CThreadBuffer& c_thread_buf,
-        index_t num_loop)
+    static __device__ void Run(const AGridDesc& a_grid_desc,
+                               const ABlockDesc& a_block_desc,
+                               ABlockTransfer& a_blockwise_copy,
+                               const AGridBuffer& a_grid_buf,
+                               ABlockBuffer& a_block_buf,
+                               const ABlockTransferStep& a_block_copy_step,
+                               const BGridDesc& b_grid_desc,
+                               const BBlockDesc& b_block_desc,
+                               BBlockTransfer& b_blockwise_copy,
+                               const BGridBuffer& b_grid_buf,
+                               BBlockBuffer& b_block_buf,
+                               const BBlockTransferStep& b_block_copy_step,
+                               const BlockwiseGemm& blockwise_gemm,
+                               CThreadBuffer& c_thread_buf,
+                               index_t num_loop)
     {
         // preload data into LDS
         a_blockwise_copy.RunRead(a_grid_desc, a_grid_buf);

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_reduce_xdl_cshuffle_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_reduce_xdl_cshuffle_v1.hpp
@@ -135,7 +135,7 @@ template <typename FloatAB,
           typename CReduceThreadClusterLengths_MPerBlock_NPerBlock,
           index_t CReduceThreadLds2VGprCopySrcDstScalarPerVector_NPerBlock,
           index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock,
-          LoopScheduler LoopSched = LoopScheduler::Default>
+          LoopScheduler LoopSched>
 struct GridwiseGemmReduce_k0mk1_k0nk1_mn_xdl_cshuffle_v1
 {
     static constexpr auto I0 = Number<0>{};

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_reduce_xdl_cshuffle_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_reduce_xdl_cshuffle_v1.hpp
@@ -134,7 +134,8 @@ template <typename FloatAB,
           index_t CShuffleBlockTransferScalarPerVector_NPerBlock,
           typename CReduceThreadClusterLengths_MPerBlock_NPerBlock,
           index_t CReduceThreadLds2VGprCopySrcDstScalarPerVector_NPerBlock,
-          index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock>
+          index_t CReduceThreadVgpr2GlobalCopySrcDstScalarPerVector_MPerBlock,
+          LoopScheduler LoopSched = LoopScheduler::Default>
 struct GridwiseGemmReduce_k0mk1_k0nk1_mn_xdl_cshuffle_v1
 {
     static constexpr auto I0 = Number<0>{};
@@ -473,17 +474,18 @@ struct GridwiseGemmReduce_k0mk1_k0nk1_mn_xdl_cshuffle_v1
         constexpr index_t KPack = math::max(
             math::lcm(AK1, BK1), MfmaSelector<FloatAB, MPerXdl, NPerXdl>::selected_mfma.k_per_blk);
 
-        auto blockwise_gemm =
-            BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1<BlockSize,
-                                                                FloatAB,
-                                                                FloatGemmAcc,
-                                                                decltype(a_block_desc_ak0_m_ak1),
-                                                                decltype(b_block_desc_bk0_n_bk1),
-                                                                MPerXdl,
-                                                                NPerXdl,
-                                                                MXdlPerWave,
-                                                                NXdlPerWave,
-                                                                KPack>{};
+        auto blockwise_gemm = BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_Selector<
+            BlockSize,
+            FloatAB,
+            FloatGemmAcc,
+            decltype(a_block_desc_ak0_m_ak1),
+            decltype(b_block_desc_bk0_n_bk1),
+            MPerXdl,
+            NPerXdl,
+            MXdlPerWave,
+            NXdlPerWave,
+            KPack,
+            LoopSched>();
 
         auto c_thread_buf = blockwise_gemm.GetCThreadBuffer();
 
@@ -502,25 +504,28 @@ struct GridwiseGemmReduce_k0mk1_k0nk1_mn_xdl_cshuffle_v1
         constexpr auto b_block_slice_copy_step = make_multi_index(KPerBlock / BK1, 0, 0);
 
         // gridwise GEMM pipeline
+        const auto gridwise_gemm_pipeline =
+            GridwiseGemmPipeline_v1_Selector<NumGemmKPrefetchStage, LoopSched>();
+
         const index_t num_k_block_main_loop = __builtin_amdgcn_readfirstlane(
             (a_grid_desc_ak0_m_ak1.GetLength(I0) * a_grid_desc_ak0_m_ak1.GetLength(I2)) /
             KPerBlock);
 
-        GridwiseGemmPipe::template Run<HasMainKBlockLoop>(a_grid_desc_ak0_m_ak1,
-                                                          a_block_desc_ak0_m_ak1,
-                                                          a_blockwise_copy,
-                                                          a_grid_buf,
-                                                          a_block_buf,
-                                                          a_block_slice_copy_step,
-                                                          b_grid_desc_bk0_n_bk1,
-                                                          b_block_desc_bk0_n_bk1,
-                                                          b_blockwise_copy,
-                                                          b_grid_buf,
-                                                          b_block_buf,
-                                                          b_block_slice_copy_step,
-                                                          blockwise_gemm,
-                                                          c_thread_buf,
-                                                          num_k_block_main_loop);
+        gridwise_gemm_pipeline.Run<HasMainKBlockLoop>(a_grid_desc_ak0_m_ak1,
+                                                      a_block_desc_ak0_m_ak1,
+                                                      a_blockwise_copy,
+                                                      a_grid_buf,
+                                                      a_block_buf,
+                                                      a_block_slice_copy_step,
+                                                      b_grid_desc_bk0_n_bk1,
+                                                      b_block_desc_bk0_n_bk1,
+                                                      b_blockwise_copy,
+                                                      b_grid_buf,
+                                                      b_block_buf,
+                                                      b_block_slice_copy_step,
+                                                      blockwise_gemm,
+                                                      c_thread_buf,
+                                                      num_k_block_main_loop);
 
         // shuffle C and write out
         {

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_reduce_xdl_cshuffle_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_reduce_xdl_cshuffle_v1.hpp
@@ -511,21 +511,21 @@ struct GridwiseGemmReduce_k0mk1_k0nk1_mn_xdl_cshuffle_v1
             (a_grid_desc_ak0_m_ak1.GetLength(I0) * a_grid_desc_ak0_m_ak1.GetLength(I2)) /
             KPerBlock);
 
-        gridwise_gemm_pipeline.Run<HasMainKBlockLoop>(a_grid_desc_ak0_m_ak1,
-                                                      a_block_desc_ak0_m_ak1,
-                                                      a_blockwise_copy,
-                                                      a_grid_buf,
-                                                      a_block_buf,
-                                                      a_block_slice_copy_step,
-                                                      b_grid_desc_bk0_n_bk1,
-                                                      b_block_desc_bk0_n_bk1,
-                                                      b_blockwise_copy,
-                                                      b_grid_buf,
-                                                      b_block_buf,
-                                                      b_block_slice_copy_step,
-                                                      blockwise_gemm,
-                                                      c_thread_buf,
-                                                      num_k_block_main_loop);
+        gridwise_gemm_pipeline.template Run<HasMainKBlockLoop>(a_grid_desc_ak0_m_ak1,
+                                                               a_block_desc_ak0_m_ak1,
+                                                               a_blockwise_copy,
+                                                               a_grid_buf,
+                                                               a_block_buf,
+                                                               a_block_slice_copy_step,
+                                                               b_grid_desc_bk0_n_bk1,
+                                                               b_block_desc_bk0_n_bk1,
+                                                               b_blockwise_copy,
+                                                               b_grid_buf,
+                                                               b_block_buf,
+                                                               b_block_slice_copy_step,
+                                                               blockwise_gemm,
+                                                               c_thread_buf,
+                                                               num_k_block_main_loop);
 
         // shuffle C and write out
         {

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_v1.hpp
@@ -454,21 +454,21 @@ struct GridwiseGemm_k0mk1_k0nk1_mn_xdl_cshuffle_v1
             (a_grid_desc_ak0_m_ak1.GetLength(I0) * a_grid_desc_ak0_m_ak1.GetLength(I2)) /
             KPerBlock);
 
-        gridwise_gemm_pipeline.Run<HasMainKBlockLoop>(a_grid_desc_ak0_m_ak1,
-                                                      a_block_desc_ak0_m_ak1,
-                                                      a_blockwise_copy,
-                                                      a_grid_buf,
-                                                      a_block_buf,
-                                                      a_block_slice_copy_step,
-                                                      b_grid_desc_bk0_n_bk1,
-                                                      b_block_desc_bk0_n_bk1,
-                                                      b_blockwise_copy,
-                                                      b_grid_buf,
-                                                      b_block_buf,
-                                                      b_block_slice_copy_step,
-                                                      blockwise_gemm,
-                                                      c_thread_buf,
-                                                      num_k_block_main_loop);
+        gridwise_gemm_pipeline.template Run<HasMainKBlockLoop>(a_grid_desc_ak0_m_ak1,
+                                                               a_block_desc_ak0_m_ak1,
+                                                               a_blockwise_copy,
+                                                               a_grid_buf,
+                                                               a_block_buf,
+                                                               a_block_slice_copy_step,
+                                                               b_grid_desc_bk0_n_bk1,
+                                                               b_block_desc_bk0_n_bk1,
+                                                               b_blockwise_copy,
+                                                               b_grid_buf,
+                                                               b_block_buf,
+                                                               b_block_slice_copy_step,
+                                                               blockwise_gemm,
+                                                               c_thread_buf,
+                                                               num_k_block_main_loop);
 
         // shuffle C and write out
         {

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_v1.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_v1.hpp
@@ -108,7 +108,7 @@ template <typename FloatAB,
           index_t CShuffleNXdlPerWavePerShuffle,
           typename CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,
           index_t CShuffleBlockTransferScalarPerVector_NPerBlock,
-          LoopScheduler LoopSched = LoopScheduler::Default>
+          LoopScheduler LoopSched>
 struct GridwiseGemm_k0mk1_k0nk1_mn_xdl_cshuffle_v1
 {
     static constexpr auto I0 = Number<0>{};

--- a/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
+++ b/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
@@ -7,6 +7,12 @@
 
 namespace ck {
 
+enum struct LoopScheduler
+{
+    Default,
+    Interwave,
+};
+
 enum struct MfmaInstr
 {
     mfma_f32_32x32x1xf32 = 0,

--- a/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
+++ b/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
@@ -13,6 +13,15 @@ enum struct LoopScheduler
     Interwave,
 };
 
+constexpr LoopScheduler make_default_loop_scheduler()
+{
+#if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
+    return LoopScheduler::Interwave;
+#else
+    return LoopScheduler::Default;
+#endif // if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
+}
+
 enum struct MfmaInstr
 {
     mfma_f32_32x32x1xf32 = 0,

--- a/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
+++ b/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
@@ -7,21 +7,6 @@
 
 namespace ck {
 
-enum struct LoopScheduler
-{
-    Default,
-    Interwave,
-};
-
-constexpr LoopScheduler make_default_loop_scheduler()
-{
-#if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
-    return LoopScheduler::Interwave;
-#else
-    return LoopScheduler::Default;
-#endif // if CK_EXPERIMENTAL_INTER_WAVE_SCHEDULING
-}
-
 enum struct MfmaInstr
 {
     mfma_f32_32x32x1xf32 = 0,


### PR DESCRIPTION
To avoid register spills seen on latest hipclang, getting best perf requires patches yet to be upstreamed + internal LLVM based off Mainline #9110 as listed here:
http://gerrit-git.amd.com/plugins/gitiles/lightning/ec/llvm-project/+/refs/heads/aukerbow/9110-ck

### Caveat
There is known verification in some `DeviceGemmXdl` kernels that have register spills. `DeviceGemmXdlCShuffle` kernels passed verifications.

List of kernels failed verification due to suspected register spill, using `./ckProfiler gemm`. A lot of false positives from BF16 verification failure is due to rounding errors

Update (5/5/2022): The latest commit 56790a62c avoids validation failure by rolling out interwave scheduling to C-shuffle gemm variants only.

<details><summary> Detail </summary>
<p>

test fp32 TT
test fp32 TN
test fp32 NT
test fp32 NN
test fp16 TT
Perf:   0.693763 ms, 1.54771 TFlops, 12.2804 GB/s, DeviceGemmXdl<256, 256, 128, 4, 8, 32, 32, 4, 2>
   max err: 4049
Perf:   0.633443 ms, 1.695088 TFlops, 13.4498 GB/s, DeviceGemmXdl<256, 128, 256, 4, 8, 32, 32, 2, 4>
   max err: 4311
Perf:   0.541443 ms, 1.983112 TFlops, 15.73514 GB/s, DeviceGemmXdl<128, 128, 128, 4, 8, 32, 32, 4, 2>
   max err: 4070
test fp16 TN
Perf:   0.425282 ms, 2.52478 TFlops, 20.033 GB/s, DeviceGemmXdl<128, 128, 128, 4, 8, 32, 32, 4, 2>
   max err: 4070
test fp16 NT
Perf:   0.577923 ms, 1.85793 TFlops, 14.7419 GB/s, DeviceGemmXdl<256, 256, 128, 4, 8, 32, 32, 4, 2>
   max err: 4049
Perf:   0.485923 ms, 2.209695 TFlops, 17.53298 GB/s, DeviceGemmXdl<128, 128, 128, 4, 8, 32, 32, 4, 2>
   max err: 4070
test fp16 NN
Perf:   0.546723 ms, 1.96396 TFlops, 15.5832 GB/s, DeviceGemmXdl<256, 256, 128, 4, 8, 32, 32, 4, 2>
   max err: 4049
Perf:   0.468322 ms, 2.292742 TFlops, 18.19193 GB/s, DeviceGemmXdl<128, 128, 128, 4, 8, 32, 32, 4, 2>
   max err: 4070
test bf16 TT
Perf:   0.723845 ms, 1.48339 TFlops, 11.77 GB/s, DeviceGemm_Xdl_CShuffle<256, 256, 128, 32, 8, 2>
   max err: 16
Perf:   0.763046 ms, 1.407178 TFlops, 11.16536 GB/s, DeviceGemm_Xdl_CShuffle<256, 256, 128, 32, 8, 8>
   max err: 16
Perf:   0.676324 ms, 1.587615 TFlops, 12.59704 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 256, 32, 8, 2>
   max err: 16
Perf:   0.674564 ms, 1.591757 TFlops, 12.62991 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 256, 32, 8, 8>
   max err: 16
Perf:   0.548483 ms, 1.957657 TFlops, 15.53317 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 128, 32, 8, 2>
   max err: 16
Perf:   0.564003 ms, 1.903787 TFlops, 15.10574 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.374082 ms, 2.870338 TFlops, 22.7749 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 128, 32, 8, 2>
   max err: 16
Perf:   0.390722 ms, 2.748097 TFlops, 21.80497 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.287841 ms, 3.73033 TFlops, 29.59856 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 64, 32, 8, 2>
   max err: 16
Perf:   0.336962 ms, 3.186537 TFlops, 25.2838 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.293601 ms, 3.657146 TFlops, 29.01788 GB/s, DeviceGemm_Xdl_CShuffle<128, 64, 128, 32, 8, 2>
   max err: 16
Perf:   0.307042 ms, 3.497052 TFlops, 27.7476 GB/s, DeviceGemm_Xdl_CShuffle<128, 64, 128, 32, 8, 8>
   max err: 16
Perf:   0.229441 ms, 4.679817 TFlops, 37.13234 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 64, 32, 8, 2>
   max err: 16
Perf:   0.282402 ms, 3.802175 TFlops, 30.16862 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.224641 ms, 4.779812 TFlops, 37.92576 GB/s, DeviceGemm_Xdl_CShuffle<256, 64, 128, 32, 8, 2>
   max err: 16
Perf:   0.236802 ms, 4.534345 TFlops, 35.97807 GB/s, DeviceGemm_Xdl_CShuffle<256, 64, 128, 32, 8, 8>
   max err: 16
test bf16 TN
Perf:   0.504483 ms, 2.1284 TFlops, 16.8879 GB/s, DeviceGemm_Xdl_CShuffle<256, 256, 128, 32, 8, 8>
   max err: 16
Perf:   0.565125 ms, 1.900008 TFlops, 15.07574 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 256, 32, 8, 8>
   max err: 16
Perf:   0.443842 ms, 2.419198 TFlops, 19.1953 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.282242 ms, 3.80433 TFlops, 30.18573 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.244321 ms, 4.3948 TFlops, 34.87085 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.260962 ms, 4.114552 TFlops, 32.64721 GB/s, DeviceGemm_Xdl_CShuffle<128, 64, 128, 32, 8, 8>
   max err: 16
Perf:   0.249121 ms, 4.310122 TFlops, 34.19896 GB/s, DeviceGemm_Xdl_CShuffle<64, 64, 64, 32, 8, 8>
   max err: 16
Perf:   0.178082 ms, 6.02948 TFlops, 47.84133 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.211681 ms, 5.072453 TFlops, 40.24773 GB/s, DeviceGemm_Xdl_CShuffle<256, 64, 128, 32, 8, 8>
   max err: 16
Perf:   0.167681 ms, 6.40348 TFlops, 50.80886 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 32, 32, 8, 8>
   max err: 16
Perf:   0.218881 ms, 4.905596 TFlops, 38.9238 GB/s, DeviceGemm_Xdl_CShuffle<128, 32, 128, 32, 8, 8>
   max err: 16
Perf:   0.158561 ms, 6.77179 TFlops, 53.73124 GB/s, DeviceGemm_Xdl_CShuffle<64, 64, 32, 32, 8, 8>
   max err: 16
Perf:    0.15584 ms, 6.890028 TFlops, 54.66941 GB/s, DeviceGemm_Xdl_CShuffle<64, 32, 64, 32, 8, 8>
   max err: 16
test bf16 NT
Perf:   0.579044 ms, 1.85434 TFlops, 14.7134 GB/s, DeviceGemm_Xdl_CShuffle<256, 256, 128, 32, 2, 2>
   max err: 16
Perf:   0.629445 ms, 1.705855 TFlops, 13.53522 GB/s, DeviceGemm_Xdl_CShuffle<256, 256, 128, 32, 8, 8>
   max err: 16
Perf:   0.579203 ms, 1.853826 TFlops, 14.70932 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 256, 32, 2, 2>
   max err: 16
Perf:   0.600004 ms, 1.789558 TFlops, 14.19937 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 256, 32, 8, 8>
   max err: 16
Perf:   0.540803 ms, 1.985458 TFlops, 15.75376 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 128, 32, 2, 2>
   max err: 16
Perf:   0.538403 ms, 1.994309 TFlops, 15.82398 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.311842 ms, 3.443224 TFlops, 27.3205 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 128, 32, 2, 2>
   max err: 16
Perf:   0.325282 ms, 3.300957 TFlops, 26.19167 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.348642 ms, 3.079783 TFlops, 24.43676 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 64, 32, 2, 2>
   max err: 16
Perf:   0.326402 ms, 3.28963 TFlops, 26.1018 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.306082 ms, 3.50802 TFlops, 27.83463 GB/s, DeviceGemm_Xdl_CShuffle<128, 64, 128, 32, 2, 2>
   max err: 16
Perf:   0.320002 ms, 3.355422 TFlops, 26.62383 GB/s, DeviceGemm_Xdl_CShuffle<128, 64, 128, 32, 8, 8>
   max err: 16
Perf:   0.198081 ms, 5.420721 TFlops, 43.01109 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 64, 32, 2, 2>
   max err: 16
Perf:   0.216161 ms, 4.967325 TFlops, 39.41359 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.195521 ms, 5.491696 TFlops, 43.57425 GB/s, DeviceGemm_Xdl_CShuffle<256, 64, 128, 32, 2, 2>
   max err: 16
Perf:   0.208961 ms, 5.13848 TFlops, 40.77163 GB/s, DeviceGemm_Xdl_CShuffle<256, 64, 128, 32, 8, 8>
   max err: 16
test bf16 NN
Perf:   0.533923 ms, 2.01104 TFlops, 15.9568 GB/s, DeviceGemm_Xdl_CShuffle<256, 256, 128, 32, 2, 8>
   max err: 16
Perf:   0.592325 ms, 1.812758 TFlops, 14.38346 GB/s, DeviceGemm_Xdl_CShuffle<256, 256, 128, 32, 8, 8>
   max err: 16
Perf:   0.530723 ms, 2.023168 TFlops, 16.05297 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 256, 32, 2, 8>
   max err: 16
Perf:   0.523203 ms, 2.052247 TFlops, 16.2837 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 256, 32, 8, 8>
   max err: 16
Perf:   0.480323 ms, 2.235458 TFlops, 17.7374 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 128, 32, 2, 8>
   max err: 16
Perf:   0.509443 ms, 2.107678 TFlops, 16.72352 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.305921 ms, 3.509866 TFlops, 27.84928 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 128, 32, 2, 8>
   max err: 16
Perf:   0.307362 ms, 3.493411 TFlops, 27.71872 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 128, 32, 8, 8>
   max err: 16
Perf:   0.278881 ms, 3.850179 TFlops, 30.54952 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 64, 32, 2, 8>
   max err: 16
Perf:   0.301922 ms, 3.556355 TFlops, 28.21815 GB/s, DeviceGemm_Xdl_CShuffle<128, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.265921 ms, 4.037823 TFlops, 32.03839 GB/s, DeviceGemm_Xdl_CShuffle<128, 64, 128, 32, 2, 8>
   max err: 16
Perf:   0.276962 ms, 3.876856 TFlops, 30.76119 GB/s, DeviceGemm_Xdl_CShuffle<128, 64, 128, 32, 8, 8>
   max err: 16
Perf:   0.189761 ms, 5.658391 TFlops, 44.8969 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 64, 32, 2, 8>
   max err: 16
Perf:   0.198241 ms, 5.416346 TFlops, 42.97638 GB/s, DeviceGemm_Xdl_CShuffle<256, 128, 64, 32, 8, 8>
   max err: 16
Perf:   0.197441 ms, 5.438292 TFlops, 43.15051 GB/s, DeviceGemm_Xdl_CShuffle<256, 64, 128, 32, 2, 8>
   max err: 16
Perf:   0.207681 ms, 5.170149 TFlops, 41.02291 GB/s, DeviceGemm_Xdl_CShuffle<256, 64, 128, 32, 8, 8>
   max err: 16
test int8 TT
test int8 TN
test int8 NT
test int8 NN

</p>
</details>