### PR TITLE
install new rocm-cmake version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,3 +88,8 @@ ADD rbuild.ini /rbuild.ini
 ADD dev-requirements.txt dev-requirements.txt
 RUN rbuild prepare -s develop -d $PREFIX
 RUN groupadd -f render
+
+# Install the new rocm-cmake version
+RUN git clone -b master https://github.com/RadeonOpenCompute/rocm-cmake.git  && \
+  cd rocm-cmake && mkdir build && cd build && \
+  cmake  .. && cmake --build . && cmake --build . --target install


### PR DESCRIPTION
This change will overwrite the rocm-cmake current version 0.7.2 with the newer 0.8.0 in the docker image used by Jenkins.