### PR TITLE
Move literal ""_uz & ""_zu into namespace 'literals'

### DIFF
--- a/example/04_gemm_add_add_fastgelu/run_gemm_add_add_fastgelu_example.inc
+++ b/example/04_gemm_add_add_fastgelu/run_gemm_add_add_fastgelu_example.inc
@@ -22,6 +22,8 @@ struct ExecutionConfig final
 
 bool run_gemm_add_add_fastgelu(const ProblemSize& problem_size, const ExecutionConfig& config)
 {
+    using namespace literals;
+
     auto& [M, N, K, StrideA, StrideB, StrideD0, StrideD1, StrideE] = problem_size;
 
     auto f_host_tensor_descriptor =

--- a/library/include/ck/library/utility/literals.hpp
+++ b/library/include/ck/library/utility/literals.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+namespace literals {
 // [P0330] Literal Suffix for (signed) size_t (C++23)
 // ref: https://wg21.link/p0330r8
 inline constexpr std::size_t operator""_uz(unsigned long long size)
@@ -14,3 +15,4 @@ inline constexpr std::size_t operator""_zu(unsigned long long size)
 {
     return static_cast<std::size_t>(size);
 }
+} // namespace literals


### PR DESCRIPTION
The compiler complains about global user-defined literals `""_uz` & `""_zu`, thus I move them into namespace `literals` to prevent the error message.  
The `literals` namespace follows the design of standard literals `std::literals`.