### PR TITLE
Add an option to build CK with clang directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ if(USE_BITINT_EXTENSION_INT4)
     message("CK compiled with USE_BITINT_EXTENSION_INT4 set to ${USE_BITINT_EXTENSION_INT4}")
 endif()
 
+## Threads
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+link_libraries(Threads::Threads)
+
 ## C++
 enable_language(CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -78,6 +83,8 @@ if( DEFINED CK_OVERRIDE_HIP_VERSION_PATCH )
     message(STATUS "CK_HIP_VERSION_PATCH overriden with ${CK_OVERRIDE_HIP_VERSION_PATCH}")
 endif()
 message(STATUS "Build with HIP ${HIP_VERSION}")
+link_libraries(hip::device)
+add_compile_definitions(__HIP_PLATFORM_HCC__=1)
 
 ## tidy
 include(EnableCompilerWarnings)
@@ -227,6 +234,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 include_directories(BEFORE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/library/include
+    ${HIP_INCLUDE_DIRS}
 )
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -596,8 +596,8 @@ pipeline {
                 {
                     agent{ label rocmnode("gfx908")}
                     environment{
-                        setup_args = """ -D  -DBUILD_DEV=Off -DCMAKE_INSTALL_PREFIX=../install CMAKE_CXX_FLAGS="--offload-arch=gfx908 -O3 " """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc .. && make -j """ 
+                        setup_args = """ -DBUILD_DEV=Off -DCMAKE_INSTALL_PREFIX=../install -D CMAKE_CXX_FLAGS="--offload-arch=gfx908 -O3 " """
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -D CMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -D CMAKE_CXX_FLAGS=" --offload-arch=gfx908 -O3" -D CMAKE_CXX_COMPILER="${compiler_path()}/clang++" .. && make -j """ 
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -597,7 +597,7 @@ pipeline {
                     agent{ label rocmnode("gfx908")}
                     environment{
                         setup_args = """ -D  -DBUILD_DEV=Off -DCMAKE_INSTALL_PREFIX=../install CMAKE_CXX_FLAGS="--offload-arch=gfx908 -O3 " """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -DCMAKE_CXX_COMPILER="${compiler_path()}/clang++" .. && make -j """ 
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc .. && make -j """ 
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,18 +23,7 @@ def getDockerImageName(){
     return img
 }
 
-def compiler_path(){
-    def path
-    if (params.COMPILER_VERSION == "release"){
-        path = "/opt/rocm/llvm/bin"
-    }
-    else{
-        path = "/llvm-project/build/bin"
-    }
-    return path
-}
-
-def build_compiler (){
+def build_compiler(){
     def compiler
     if (params.BUILD_COMPILER == "hipcc"){
         compiler = '/opt/rocm/bin/hipcc'
@@ -130,11 +119,7 @@ def buildDocker(install_prefix){
 
 def cmake_build(Map conf=[:]){
 
-    def path = compiler_path()
-    def compiler = conf.get("compiler","/opt/rocm/bin/hipcc")
-    if (params.BUILD_COMPILER != "hipcc"){
-        compiler = conf.get("compiler","${path}/clang++")
-    }
+    def compiler = build_compiler()
     def config_targets = conf.get("config_targets","check")
     def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined " + conf.get("extradebugflags", "")
     def build_envs = "CTEST_PARALLEL_LEVEL=4 " + conf.get("build_env","")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,11 +131,9 @@ def buildDocker(install_prefix){
 def cmake_build(Map conf=[:]){
 
     def path = compiler_path()
-    if (params.BUILD_COMPILER == "hipcc"){
-        def compiler = conf.get("compiler","/opt/rocm/bin/hipcc")
-    }
-    else{
-        def compiler = conf.get("compiler","${path}/clang++")
+    def compiler = conf.get("compiler","/opt/rocm/bin/hipcc")
+    if (params.BUILD_COMPILER != "hipcc"){
+        compiler = conf.get("compiler","${path}/clang++")
     }
     def config_targets = conf.get("config_targets","check")
     def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined " + conf.get("extradebugflags", "")


### PR DESCRIPTION
This change will enable building CK with clang, using any version of compiler (e.g., 5.1.0 release, ck-9110 (default), or amd-stg-open). There will be a new build parameter "BUILD_COMPILER" set to "hipcc" by default. When set to "clang" or any other value, it will use clang.