### PR TITLE
Add debug message for IsSupportedArgument()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 message("CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
 
+## Debug Usage
+option(ENABLE_CK_DEBUG, "Whether to compile CK as debug message enabled." OFF)
+
+if(ENABLE_CK_DEBUG)
+    add_compile_definitions(ENABLE_CK_DEBUG)
+    message("Debug message enabled. This may slow down execution.")
+endif(ENABLE_CK_DEBUG)
+
 ## OpenMP
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	# workaround issue hipcc in rocm3.5 cannot find openmp

--- a/include/ck/tensor_operation/gpu/device/device_grouped_conv_fwd_multiple_d_multiple_r_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_grouped_conv_fwd_multiple_d_multiple_r_xdl_cshuffle.hpp
@@ -892,9 +892,11 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
                      is_same_v<ALayout, ctc::NWGC> || is_same_v<ALayout, ctc::NHWGC> ||
                      is_same_v<ALayout, ctc::NDHWGC>)
         {
+            static_assert(ABlockTransferSrcVectorDim == 2);
+
             const index_t C = arg.a_g_n_c_wis_lengths_[2];
 
-            if(!(ABlockTransferSrcVectorDim == 2 && C % ABlockTransferSrcScalarPerVector == 0))
+            if(!(C % ABlockTransferSrcScalarPerVector == 0))
             {
                 CK_DEBUG(
                     std::cerr
@@ -921,9 +923,11 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
                      is_same_v<BLayout, ctc::KZYXGC>)
 
         {
+            static_assert(BBlockTransferSrcVectorDim == 2);
+
             const index_t C = arg.b_g_k_c_xs_lengths_[2];
 
-            if(!(BBlockTransferSrcVectorDim == 2 && C % BBlockTransferSrcScalarPerVector == 0))
+            if(!(C % BBlockTransferSrcScalarPerVector == 0))
             {
                 CK_DEBUG(
                     std::cerr

--- a/include/ck/tensor_operation/gpu/device/device_grouped_conv_fwd_multiple_d_multiple_r_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_grouped_conv_fwd_multiple_d_multiple_r_xdl_cshuffle.hpp
@@ -808,6 +808,8 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
             if constexpr(!(is_same_v<AccDataType, float> || is_same_v<AccDataType, float> ||
                            is_same_v<AccDataType, int32_t>))
             {
+                CK_DEBUG(std::cerr << "Invalid AccDataType for gfx908 (" << __FILE__ << ":"
+                                   << __LINE__ << ")" << std::endl;)
                 return false;
             }
         }
@@ -816,11 +818,15 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
             if constexpr(!(is_same_v<AccDataType, float> || is_same_v<AccDataType, float> ||
                            is_same_v<AccDataType, int32_t> || is_same_v<AccDataType, double>))
             {
+                CK_DEBUG(std::cerr << "Invalid AccDataType for gfx90a (" << __FILE__ << ":"
+                                   << __LINE__ << ")" << std::endl;)
                 return false;
             }
         }
         else
         {
+            CK_DEBUG(std::cerr << "Invalid device name: " << get_device_name() << " (" << __FILE__
+                               << ":" << __LINE__ << ")" << std::endl;)
             return false;
         }
 
@@ -838,6 +844,17 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
 
                 if(!(X == 1 && ConvStride == 1 && LeftPad == 0 && RightPad == 0))
                 {
+                    CK_DEBUG(
+                        if(!(X == 1)) {
+                            std::cerr << "Unsatisfied filter shape (" << __FILE__ << ":" << __LINE__
+                                      << ")" << std::endl;
+                        } else if(!(ConvStride == 1)) {
+                            std::cerr << "Unsatisfied filter stride (" << __FILE__ << ":"
+                                      << __LINE__ << ")" << std::endl;
+                        } else if(!(LeftPad == 0 && RightPad == 0)) {
+                            std::cerr << "Unsatisfied padding (" << __FILE__ << ":" << __LINE__
+                                      << ")" << std::endl;
+                        })
                     return false;
                 }
             }
@@ -854,6 +871,14 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
 
                 if(!(X == 1 && LeftPad == 0 && RightPad == 0))
                 {
+                    CK_DEBUG(
+                        if(!(X == 1)) {
+                            std::cerr << "Unsatisfied filter shape (" << __FILE__ << ":" << __LINE__
+                                      << ")" << std::endl;
+                        } else if(!(LeftPad == 0 && RightPad == 0)) {
+                            std::cerr << "Unsatisfied padding (" << __FILE__ << ":" << __LINE__
+                                      << ")" << std::endl;
+                        })
                     return false;
                 }
             }
@@ -871,11 +896,19 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
 
             if(!(ABlockTransferSrcVectorDim == 2 && C % ABlockTransferSrcScalarPerVector == 0))
             {
+                CK_DEBUG(
+                    std::cerr
+                        << "Dimension C (=" << C
+                        << ") of tensor A is not dividable by ABlockTransferSrcScalarPerVector (="
+                        << ABlockTransferSrcScalarPerVector << ") (" << __FILE__ << ":" << __LINE__
+                        << ")" << std::endl;)
                 return false;
             }
         }
         else
         {
+            CK_DEBUG(std::cerr << "Invalid tensor layout for tensor A (" << __FILE__ << ":"
+                               << __LINE__ << ")" << std::endl;)
             return false;
         }
 
@@ -892,11 +925,19 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
 
             if(!(BBlockTransferSrcVectorDim == 2 && C % BBlockTransferSrcScalarPerVector == 0))
             {
+                CK_DEBUG(
+                    std::cerr
+                        << "Dimension C (=" << C
+                        << ") of tensor B is not dividable by BBlockTransferSrcScalarPerVector (="
+                        << BBlockTransferSrcScalarPerVector << ") (" << __FILE__ << ":" << __LINE__
+                        << ")" << std::endl;)
                 return false;
             }
         }
         else
         {
+            CK_DEBUG(std::cerr << "Invalid tensor layout for tensor B (" << __FILE__ << ":"
+                               << __LINE__ << ")" << std::endl;)
             return false;
         }
 
@@ -915,11 +956,18 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
 
                 if(!(K % CDEBlockTransferScalarPerVector_NPerBlock == 0))
                 {
+                    CK_DEBUG(std::cerr << "Dimension K (=" << K
+                                       << ") of tensor D is not dividable by "
+                                          "CDEBlockTransferScalarPerVector_NPerBlock (="
+                                       << CDEBlockTransferScalarPerVector_NPerBlock << ") ("
+                                       << __FILE__ << ":" << __LINE__ << ")" << std::endl;)
                     valid = false;
                 }
             }
             else
             {
+                CK_DEBUG(std::cerr << "Invalid tensor layout for tensor D (" << __FILE__ << ":"
+                                   << __LINE__ << ")" << std::endl;)
                 valid = false;
             }
         });
@@ -940,11 +988,18 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
 
             if(!(K % CDEBlockTransferScalarPerVector_NPerBlock == 0))
             {
+                CK_DEBUG(std::cerr << "Dimension K (=" << K
+                                   << ") of tensor E is not dividable by "
+                                      "CDEBlockTransferScalarPerVector_NPerBlock (="
+                                   << CDEBlockTransferScalarPerVector_NPerBlock << ") (" << __FILE__
+                                   << ":" << __LINE__ << ")" << std::endl;)
                 return false;
             }
         }
         else
         {
+            CK_DEBUG(std::cerr << "Invalid tensor layout for tensor E (" << __FILE__ << ":"
+                               << __LINE__ << ")" << std::endl;)
             return false;
         }
 
@@ -955,6 +1010,9 @@ struct DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle
                        is_same_v<RLayout, ctc::NWG> || is_same_v<RLayout, ctc::NHWG> ||
                        is_same_v<RLayout, ctc::NDHWG>))
         {
+
+            CK_DEBUG(std::cerr << "Invalid tensor layout for tensor R (" << __FILE__ << ":"
+                               << __LINE__ << ")" << std::endl;)
             return false;
         }
 

--- a/include/ck/utility/debug.hpp
+++ b/include/ck/utility/debug.hpp
@@ -4,6 +4,15 @@
 #ifndef UTILITY_DEBUG_HPP
 #define UTILITY_DEBUG_HPP
 
+#ifdef ENABLE_CK_DEBUG
+#define CK_DEBUG(stmts) \
+    {                   \
+        stmts           \
+    }
+#else
+#define CK_DEBUG(stmts)
+#endif
+
 namespace ck {
 namespace debug {
 


### PR DESCRIPTION
I did following things in this PR:

- Add `CK_DEBUG()` macro to wrap debug code (we can switch it on/off by `ENABLE_CK_DEBUG` option). It's design is similar with [`LLVM_DEBUG()`](https://llvm.org/docs/ProgrammersManual.html#the-llvm-debug-macro-and-debug-option), but exclude trailing semicolon
- Use `CK_DEBUG()` to add debug messages for `DeviceGroupedConvFwdMultipleDMultipleR_Xdl_CShuffle::IsSupportedArgument()`