### PR TITLE
Simplify examples, tests and profiler

### DIFF
--- a/example/01_gemm/gemm_xdl_skip_b_lds_fp16.cpp
+++ b/example/01_gemm/gemm_xdl_skip_b_lds_fp16.cpp
@@ -63,10 +63,10 @@ template <typename DataType>
 std::ostream& show_2d_matrix(std::ostream& os, Tensor<DataType>& matrix)
 {
     os << "[" << std::endl;
-    for(size_t x = 0; x < matrix.mDesc.GetLengths()[0]; x++)
+    for(size_t x = 0; x < matrix.GetLengths()[0]; x++)
     {
         os << "[";
-        for(size_t y = 0; y < matrix.mDesc.GetLengths()[1]; y++)
+        for(size_t y = 0; y < matrix.GetLengths()[1]; y++)
         {
             os << std::setw(5) << static_cast<float>(matrix(x, y));
         }
@@ -133,17 +133,17 @@ int main(int argc, char* argv[])
         exit(0);
     }
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-            if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
+            if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -152,9 +152,9 @@ int main(int argc, char* argv[])
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "c_m_n: " << c_m_n_host_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "c_m_n: " << c_m_n_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -173,12 +173,12 @@ int main(int argc, char* argv[])
         b_k_n.GenerateTensorValue(GeneratorTensor_1<ADataType>{1});
     }
 
-    DeviceMem a_m_k_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_k_n_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_m_n_device_buf(sizeof(CDataType) * c_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_m_k_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_k_n_device_buf(b_k_n.GetMemorySize());
+    DeviceMem c_m_n_device_buf(c_m_n_device_result.GetMemorySize());
 
-    a_m_k_device_buf.ToDevice(a_m_k.mData.data());
-    b_k_n_device_buf.ToDevice(b_k_n.mData.data());
+    a_m_k_device_buf.ToDevice(a_m_k.data());
+    b_k_n_device_buf.ToDevice(b_k_n.data());
 
     auto a_element_op = AElementOp{};
     auto b_element_op = BElementOp{};
@@ -187,9 +187,9 @@ int main(int argc, char* argv[])
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-                                      static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-                                      static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
+    auto argument = gemm.MakeArgument(a_m_k_device_buf.GetDeviceBuffer(),
+                                      b_k_n_device_buf.GetDeviceBuffer(),
+                                      c_m_n_device_buf.GetDeviceBuffer(),
                                       M,
                                       N,
                                       K,
@@ -220,7 +220,7 @@ int main(int argc, char* argv[])
     std::cout << "Perf: " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
               << gemm.GetTypeString() << std::endl;
 
-    c_m_n_device_buf.FromDevice(c_m_n_device_result.mData.data());
+    c_m_n_device_buf.FromDevice(c_m_n_device_result.data());
 
     if(do_verification)
     {
@@ -240,7 +240,7 @@ int main(int argc, char* argv[])
             show_2d_matrix(std::cout << "c_host  :", c_m_n_host_result) << std::endl;
         }
 #endif
-        ck::utils::check_err(c_m_n_device_result.mData, c_m_n_host_result.mData);
+        ck::utils::check_err(c_m_n_device_result, c_m_n_host_result);
     }
 
     return 0;

--- a/example/01_gemm/run_gemm_example.inc
+++ b/example/01_gemm/run_gemm_example.inc
@@ -9,9 +9,9 @@ bool run_gemm(const ProblemSize& problem_size, const ExecutionConfig& config)
     static_assert(sizeof(ck::int4_t) == sizeof(int8_t));
 #endif
 
-    using namespace ck::literals;
-
     auto& [M, N, K, StrideA, StrideB, StrideC] = problem_size;
+
+    using namespace ck::literals;
 
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
@@ -32,41 +32,38 @@ bool run_gemm(const ProblemSize& problem_size, const ExecutionConfig& config)
     {
     case 0: break;
     case 1:
-        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-5.f, 5.f}(a_m_k.begin(),
-                                                                             a_m_k.end());
-        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-5.f, 5.f}(b_k_n.begin(),
-                                                                             b_k_n.end());
+        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-5.f, 5.f}(a_m_k);
+        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-5.f, 5.f}(b_k_n);
         break;
     default:
-        ck::utils::FillUniformDistribution<ADataType>{-1.f, 1.f}(a_m_k.begin(), a_m_k.end());
-        ck::utils::FillUniformDistribution<BDataType>{-1.f, 1.f}(b_k_n.begin(), b_k_n.end());
+        ck::utils::FillUniformDistribution<ADataType>{-1.f, 1.f}(a_m_k);
+        ck::utils::FillUniformDistribution<BDataType>{-1.f, 1.f}(b_k_n);
     }
 
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "c_m_n: " << c_m_n_host_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "c_m_n: " << c_m_n_host_result.GetDesc() << std::endl;
 
 #ifdef BUILD_INT4_EXAMPLE
-    DeviceMem a_m_k_device_buf(sizeof(KernelADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_k_n_device_buf(sizeof(KernelBDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_m_n_device_buf(sizeof(KernelCDataType) *
-                               c_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_m_k_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_k_n_device_buf(b_k_n.GetMemorySize());
+    DeviceMem c_m_n_device_buf(c_m_n_device_result.GetMemorySize());
 
     const Tensor<KernelADataType> a_m_k_converted(a_m_k);
     const Tensor<KernelBDataType> b_k_n_converted(b_k_n);
 
-    a_m_k_device_buf.ToDevice(a_m_k_converted.mData.data());
-    b_k_n_device_buf.ToDevice(b_k_n_converted.mData.data());
+    a_m_k_device_buf.ToDevice(a_m_k_converted.data());
+    b_k_n_device_buf.ToDevice(b_k_n_converted.data());
 #else
-    DeviceMem a_m_k_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_k_n_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_m_n_device_buf(sizeof(CDataType) * c_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_m_k_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_k_n_device_buf(b_k_n.GetMemorySize());
+    DeviceMem c_m_n_device_buf(c_m_n_device_result.GetMemorySize());
 
-    a_m_k_device_buf.ToDevice(a_m_k.mData.data());
-    b_k_n_device_buf.ToDevice(b_k_n.mData.data());
+    a_m_k_device_buf.ToDevice(a_m_k.data());
+    b_k_n_device_buf.ToDevice(b_k_n.data());
 #endif
 
     auto a_element_op = AElementOp{};
@@ -76,25 +73,18 @@ bool run_gemm(const ProblemSize& problem_size, const ExecutionConfig& config)
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<KernelBDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<KernelCDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
-#endif
-        M,
-        N,
-        K,
-        StrideA,
-        StrideB,
-        StrideC,
-        a_element_op,
-        b_element_op,
-        c_element_op);
+    auto argument = gemm.MakeArgument(a_m_k_device_buf.GetDeviceBuffer(),
+                                      b_k_n_device_buf.GetDeviceBuffer(),
+                                      c_m_n_device_buf.GetDeviceBuffer(),
+                                      M,
+                                      N,
+                                      K,
+                                      StrideA,
+                                      StrideB,
+                                      StrideC,
+                                      a_element_op,
+                                      b_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {
@@ -127,17 +117,17 @@ bool run_gemm(const ProblemSize& problem_size, const ExecutionConfig& config)
         ref_invoker.Run(ref_argument);
 
 #ifdef BUILD_INT4_EXAMPLE
-        Tensor<CDataType> c_m_n_device_result_converted(c_m_n_host_result.mDesc);
+        Tensor<CDataType> c_m_n_device_result_converted(c_m_n_host_result.GetDesc());
 
-        c_m_n_device_buf.FromDevice(c_m_n_device_result_converted.mData.data());
+        c_m_n_device_buf.FromDevice(c_m_n_device_result_converted.data());
 
         c_m_n_device_result = c_m_n_device_result_converted.CopyAsType<CDataType>();
 
-        return ck::utils::check_err(c_m_n_device_result_converted.mData, c_m_n_host_result.mData);
+        return ck::utils::check_err(c_m_n_device_result_converted, c_m_n_host_result);
 #else
-        c_m_n_device_buf.FromDevice(c_m_n_device_result.mData.data());
+        c_m_n_device_buf.FromDevice(c_m_n_device_result.data());
 
-        return ck::utils::check_err(c_m_n_device_result.mData, c_m_n_host_result.mData);
+        return ck::utils::check_err(c_m_n_device_result, c_m_n_host_result);
 #endif
     }
 

--- a/example/02_gemm_bilinear/gemm_bilinear_xdl_fp16.cpp
+++ b/example/02_gemm_bilinear/gemm_bilinear_xdl_fp16.cpp
@@ -272,7 +272,7 @@ int main(int argc, char* argv[])
 
     if(do_verification)
     {
-        Tensor<CShuffleDataType> c_m_n(HostTensorDescriptor({M, N}));
+        Tensor<CShuffleDataType> c_m_n({M, N});
 
         using ReferenceGemmInstance = ck::tensor_operation::host::ReferenceGemm<ADataType,
                                                                                 BDataType,

--- a/example/03_gemm_bias_relu/gemm_bias_relu_xdl_fp16.cpp
+++ b/example/03_gemm_bias_relu/gemm_bias_relu_xdl_fp16.cpp
@@ -1,22 +1,24 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/device_gemm_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/array.hpp"
+#include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/literals.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -153,17 +155,17 @@ int main(int argc, char* argv[])
         exit(0);
     }
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-            if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
+            if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -173,10 +175,10 @@ int main(int argc, char* argv[])
     Tensor<EDataType> e_m_n_host_result(f_host_tensor_descriptor(M, N, StrideE, ELayout{}));
     Tensor<EDataType> e_m_n_device_result(f_host_tensor_descriptor(M, N, StrideE, ELayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "d_m_n: " << d_m_n.mDesc << std::endl;
-    std::cout << "e_m_n: " << e_m_n_host_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "d_m_n: " << d_m_n.GetDesc() << std::endl;
+    std::cout << "e_m_n: " << e_m_n_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -192,14 +194,14 @@ int main(int argc, char* argv[])
         d_m_n.GenerateTensorValue(GeneratorTensor_3<DDataType>{0.0, 1.0});
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem d_device_buf(sizeof(DDataType) * d_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) * e_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem d_device_buf(d_m_n.GetMemorySize());
+    DeviceMem e_device_buf(e_m_n_device_result.GetMemorySize());
 
-    a_device_buf.ToDevice(a_m_k.mData.data());
-    b_device_buf.ToDevice(b_k_n.mData.data());
-    d_device_buf.ToDevice(d_m_n.mData.data());
+    a_device_buf.ToDevice(a_m_k.data());
+    b_device_buf.ToDevice(b_k_n.data());
+    d_device_buf.ToDevice(d_m_n.data());
 
     auto a_element_op   = AElementOp{};
     auto b_element_op   = BElementOp{};
@@ -210,21 +212,20 @@ int main(int argc, char* argv[])
 
     auto invoker = device_op.MakeInvoker();
 
-    auto argument =
-        device_op.MakeArgument(a_device_buf.GetDeviceBuffer(),
-                               b_device_buf.GetDeviceBuffer(),
-                               std::array<const void*, 1>{d_device_buf.GetDeviceBuffer()},
-                               e_device_buf.GetDeviceBuffer(),
-                               M,
-                               N,
-                               K,
-                               StrideA,
-                               StrideB,
-                               std::array<ck::index_t, 1>{0},
-                               StrideE,
-                               a_element_op,
-                               b_element_op,
-                               cde_element_op);
+    auto argument = device_op.MakeArgument(a_device_buf.GetDeviceBuffer(),
+                                           b_device_buf.GetDeviceBuffer(),
+                                           ck::utils::to_array({d_device_buf.GetDeviceBuffer()}),
+                                           e_device_buf.GetDeviceBuffer(),
+                                           M,
+                                           N,
+                                           K,
+                                           StrideA,
+                                           StrideB,
+                                           ck::utils::to_array({0}),
+                                           StrideE,
+                                           a_element_op,
+                                           b_element_op,
+                                           cde_element_op);
 
     if(!device_op.IsSupportedArgument(argument))
     {
@@ -247,7 +248,7 @@ int main(int argc, char* argv[])
 
     if(do_verification)
     {
-        e_device_buf.FromDevice(e_m_n_device_result.mData.data());
+        e_device_buf.FromDevice(e_m_n_device_result.data());
 
         Tensor<AccDataType> c_m_n(f_host_tensor_descriptor(M, N, StrideE, ELayout{}));
 
@@ -275,7 +276,7 @@ int main(int argc, char* argv[])
             }
         }
 
-        return ck::utils::check_err(e_m_n_device_result.mData, e_m_n_host_result.mData) ? 0 : 1;
+        return ck::utils::check_err(e_m_n_device_result, e_m_n_host_result) ? 0 : 1;
     }
 
     return 0;

--- a/example/04_gemm_add_add_fastgelu/run_gemm_add_add_fastgelu_example.inc
+++ b/example/04_gemm_add_add_fastgelu/run_gemm_add_add_fastgelu_example.inc
@@ -35,11 +35,11 @@ bool run_gemm_add_add_fastgelu(const ProblemSize& problem_size, const ExecutionC
         >
         e_m_n_device_result(f_host_tensor_descriptor(M, N, StrideE, ELayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "d0_m_n: " << d0_m_n.mDesc << std::endl;
-    std::cout << "d1_m_n: " << d1_m_n.mDesc << std::endl;
-    std::cout << "e_m_n: " << e_m_n_host_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "d0_m_n: " << d0_m_n.GetDesc() << std::endl;
+    std::cout << "d1_m_n: " << d1_m_n.GetDesc() << std::endl;
+    std::cout << "e_m_n: " << e_m_n_host_result.GetDesc() << std::endl;
 
     switch(config.init_method)
     {
@@ -57,11 +57,11 @@ bool run_gemm_add_add_fastgelu(const ProblemSize& problem_size, const ExecutionC
         d1_m_n.GenerateTensorValue(GeneratorTensor_3<D1DataType>{0.0, 1.0});
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem d0_device_buf(sizeof(D0DataType) * d0_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem d1_device_buf(sizeof(D1DataType) * d1_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) * e_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem d0_device_buf(d0_m_n.GetMemorySize());
+    DeviceMem d1_device_buf(d1_m_n.GetMemorySize());
+    DeviceMem e_device_buf(e_m_n_device_result.GetMemorySize());
 
 #ifdef BUILD_INT4_EXAMPLE
     const Tensor<KernelADataType> a_m_k_converted(a_m_k);
@@ -69,15 +69,15 @@ bool run_gemm_add_add_fastgelu(const ProblemSize& problem_size, const ExecutionC
     const Tensor<KernelD0DataType> d0_m_n_converted(d0_m_n);
     const Tensor<KernelD1DataType> d1_m_n_converted(d1_m_n);
 
-    a_device_buf.ToDevice(a_m_k_converted.mData.data());
-    b_device_buf.ToDevice(b_k_n_converted.mData.data());
-    d0_device_buf.ToDevice(d0_m_n_converted.mData.data());
-    d1_device_buf.ToDevice(d1_m_n_converted.mData.data());
+    a_device_buf.ToDevice(a_m_k_converted.data());
+    b_device_buf.ToDevice(b_k_n_converted.data());
+    d0_device_buf.ToDevice(d0_m_n_converted.data());
+    d1_device_buf.ToDevice(d1_m_n_converted.data());
 #else
-    a_device_buf.ToDevice(a_m_k.mData.data());
-    b_device_buf.ToDevice(b_k_n.mData.data());
-    d0_device_buf.ToDevice(d0_m_n.mData.data());
-    d1_device_buf.ToDevice(d1_m_n.mData.data());
+    a_device_buf.ToDevice(a_m_k.data());
+    b_device_buf.ToDevice(b_k_n.data());
+    d0_device_buf.ToDevice(d0_m_n.data());
+    d1_device_buf.ToDevice(d1_m_n.data());
 #endif
 
     auto a_element_op   = AElementOp{};
@@ -142,14 +142,14 @@ bool run_gemm_add_add_fastgelu(const ProblemSize& problem_size, const ExecutionC
             }
         }
 
-        e_device_buf.FromDevice(e_m_n_device_result.mData.data());
+        e_device_buf.FromDevice(e_m_n_device_result.data());
 
 #ifdef BUILD_INT4_EXAMPLE
         const Tensor<EDataType> e_m_n_device_result_converted(e_m_n_device_result);
 
-        return ck::utils::check_err(e_m_n_device_result_converted.mData, e_m_n_host_result.mData);
+        return ck::utils::check_err(e_m_n_device_result_converted, e_m_n_host_result);
 #else
-        return ck::utils::check_err(e_m_n_device_result.mData, e_m_n_host_result.mData);
+        return ck::utils::check_err(e_m_n_device_result, e_m_n_host_result);
 #endif
     }
 

--- a/example/10_convnd_fwd_multiple_d_multiple_reduce/common.hpp
+++ b/example/10_convnd_fwd_multiple_d_multiple_reduce/common.hpp
@@ -16,6 +16,9 @@
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/algorithm.hpp"
+#include "ck/library/utility/array.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
@@ -23,7 +26,6 @@
 #include "ck/library/utility/fill.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
 
 using BF16 = ck::bhalf_t;
 using FP16 = ck::half_t;
@@ -140,9 +142,7 @@ make_r0_host_tensor_descriptor(const ck::utils::conv::ConvParam& problem_size)
 {
     std::vector<ck::index_t> dimensions{problem_size.G_, problem_size.N_};
 
-    std::copy(begin(problem_size.output_spatial_lengths_),
-              end(problem_size.output_spatial_lengths_),
-              std::back_inserter(dimensions));
+    ck::ranges::copy(problem_size.output_spatial_lengths_, std::back_inserter(dimensions));
 
     return HostTensorDescriptor(dimensions);
 }
@@ -157,11 +157,4 @@ void unpack_host_tensor_descriptor(const HostTensorDescriptor& descriptor,
 
     assert(size(descriptor.GetStrides()) == size(strides));
     std::copy_n(begin(descriptor.GetStrides()), size(descriptor.GetStrides()), begin(strides));
-}
-
-template <typename Range, typename OutputIterator>
-auto copy(const Range& range, OutputIterator iter)
-    -> decltype(std::copy(std::begin(range), std::end(range), iter))
-{
-    return std::copy(std::begin(range), std::end(range), iter);
 }

--- a/example/10_convnd_fwd_multiple_d_multiple_reduce/run_convnd_fwd_max_example.inc
+++ b/example/10_convnd_fwd_multiple_d_multiple_reduce/run_convnd_fwd_max_example.inc
@@ -77,32 +77,28 @@ bool run_convnd_fwd_max(const ck::utils::conv::ConvParam& problem_size,
     {
     case 0: break;
     case 1:
-        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-8, 7}(conv_input.begin(),
-                                                                         conv_input.end());
-        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-8, 7}(conv_weight.begin(),
-                                                                         conv_weight.end());
+        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-8, 7}(conv_input);
+        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-8, 7}(conv_weight);
         break;
     default:
-        ck::utils::FillUniformDistribution<ADataType>{-5, 5}(conv_input.begin(), conv_input.end());
-        ck::utils::FillUniformDistribution<BDataType>{-5, 5}(conv_weight.begin(),
-                                                             conv_weight.end());
+        ck::utils::FillUniformDistribution<ADataType>{-5, 5}(conv_input);
+        ck::utils::FillUniformDistribution<BDataType>{-5, 5}(conv_weight);
     }
 
-    DeviceMem conv_input_device_buf(sizeof(ADataType) * conv_input.mDesc.GetElementSpaceSize());
-    DeviceMem conv_weight_device_buf(sizeof(BDataType) * conv_weight.mDesc.GetElementSpaceSize());
-    DeviceMem conv_output_device_buf(sizeof(EDataType) *
-                                     conv_output_device.mDesc.GetElementSpaceSize());
-    DeviceMem r0_device_buf(sizeof(R0DataType) * r0_device.mDesc.GetElementSpaceSize());
+    DeviceMem conv_input_device_buf(conv_input.GetMemorySize());
+    DeviceMem conv_weight_device_buf(conv_weight.GetMemorySize());
+    DeviceMem conv_output_device_buf(conv_output_device.GetMemorySize());
+    DeviceMem r0_device_buf(r0_device.GetMemorySize());
 
 #ifdef BUILD_INT4_EXAMPLE
     const Tensor<KernelADataType> conv_input_converted(conv_input);
     const Tensor<KernelBDataType> conv_weight_converted(conv_weight);
 
-    conv_input_device_buf.ToDevice(conv_input_converted.mData.data());
-    conv_weight_device_buf.ToDevice(conv_weight_converted.mData.data());
+    conv_input_device_buf.ToDevice(conv_input_converted.data());
+    conv_weight_device_buf.ToDevice(conv_weight_converted.data());
 #else
-    conv_input_device_buf.ToDevice(conv_input.mData.data());
-    conv_weight_device_buf.ToDevice(conv_weight.mData.data());
+    conv_input_device_buf.ToDevice(conv_input.data());
+    conv_weight_device_buf.ToDevice(conv_weight.data());
 #endif
 
     std::array<ck::index_t, NDimSpatial + 3> conv_input_g_n_c_wis_lengths{},
@@ -112,8 +108,6 @@ bool run_convnd_fwd_max(const ck::utils::conv::ConvParam& problem_size,
     std::array<ck::index_t, NDimSpatial + 3> conv_output_g_n_k_wos_lengths{},
         conv_output_g_n_k_wos_strides{};
     std::array<ck::index_t, NDimSpatial + 2> r0_lengths{}, r0_strides{};
-    std::array<ck::index_t, NDimSpatial> conv_filter_strides{}, conv_filter_dilations{};
-    std::array<ck::index_t, NDimSpatial> input_left_pads{}, input_right_pads{};
 
     unpack_host_tensor_descriptor(
         conv_input_g_n_c_wis_desc, conv_input_g_n_c_wis_lengths, conv_input_g_n_c_wis_strides);
@@ -123,33 +117,30 @@ bool run_convnd_fwd_max(const ck::utils::conv::ConvParam& problem_size,
         conv_output_g_n_k_wos_desc, conv_output_g_n_k_wos_lengths, conv_output_g_n_k_wos_strides);
     unpack_host_tensor_descriptor(r0_desc, r0_lengths, r0_strides);
 
-    copy(problem_size.conv_filter_strides_, begin(conv_filter_strides));
-    copy(problem_size.conv_filter_dilations_, begin(conv_filter_dilations));
-    copy(problem_size.input_left_pads_, begin(input_left_pads));
-    copy(problem_size.input_right_pads_, begin(input_right_pads));
+    using ck::utils::empty_array, ck::utils::to_array;
 
     // run Conv + Reduction on device
     auto conv     = DeviceInstance<NDimSpatial>{};
     auto invoker  = conv.MakeInvoker();
     auto argument = conv.MakeArgument(conv_input_device_buf.GetDeviceBuffer(),
                                       conv_weight_device_buf.GetDeviceBuffer(),
-                                      std::array<const void*, 0>{},
+                                      empty_array(),
                                       conv_output_device_buf.GetDeviceBuffer(),
                                       {r0_device_buf.GetDeviceBuffer()},
                                       conv_input_g_n_c_wis_lengths,
                                       conv_input_g_n_c_wis_strides,
                                       conv_weight_g_k_c_xs_lengths,
                                       conv_weight_g_k_c_xs_strides,
-                                      std::array<std::array<ck::index_t, NDimSpatial + 3>, 0>{{}},
-                                      std::array<std::array<ck::index_t, NDimSpatial + 3>, 0>{{}},
+                                      empty_array(),
+                                      empty_array(),
                                       conv_output_g_n_k_wos_lengths,
                                       conv_output_g_n_k_wos_strides,
                                       r0_lengths,
                                       r0_strides,
-                                      conv_filter_strides,
-                                      conv_filter_dilations,
-                                      input_left_pads,
-                                      input_right_pads,
+                                      to_array(problem_size.conv_filter_strides_),
+                                      to_array(problem_size.conv_filter_dilations_),
+                                      to_array(problem_size.input_left_pads_),
+                                      to_array(problem_size.input_right_pads_),
                                       AElementOp{},
                                       BElementOp{},
                                       CDEElementOp{},
@@ -194,11 +185,11 @@ bool run_convnd_fwd_max(const ck::utils::conv::ConvParam& problem_size,
 
         ref_invoker.Run(ref_argument);
 
-        Tensor<R0DataType> r0_host(r0_device.mDesc);
+        Tensor<R0DataType> r0_host(r0_device.GetDesc());
 
         auto reduce0_op = RsThreadReduceOp{}[ck::Number<0>{}];
 
-        auto& output_dims = conv_output_g_n_k_wos_desc.GetLengths();
+        auto output_dims = conv_output_g_n_k_wos_desc.GetLengths();
 
         if constexpr(NDimSpatial == 1)
         {
@@ -273,19 +264,16 @@ bool run_convnd_fwd_max(const ck::utils::conv::ConvParam& problem_size,
             }
         }
 
-        conv_output_device_buf.FromDevice(conv_output_device.mData.data());
-        r0_device_buf.FromDevice(r0_device.mData.data());
+        conv_output_device_buf.FromDevice(conv_output_device.data());
+        r0_device_buf.FromDevice(r0_device.data());
 
-        return ck::utils::check_err(conv_output_device.mData,
-                                    conv_output_host.mData,
+        return ck::utils::check_err(conv_output_device,
+                                    conv_output_host,
                                     "Error: incorrect results! (Matrix E)",
                                     1e-5f,
                                     1e-4f) &&
-               ck::utils::check_err(r0_device.mData,
-                                    r0_host.mData,
-                                    "Error: incorrect results! (Matrix R0)",
-                                    1e-5f,
-                                    1e-4f);
+               ck::utils::check_err(
+                   r0_device, r0_host, "Error: incorrect results! (Matrix R0)", 1e-5f, 1e-4f);
     }
 
     return true;

--- a/example/12_reduce/reduce_blockwise_impl.hpp
+++ b/example/12_reduce/reduce_blockwise_impl.hpp
@@ -7,15 +7,17 @@
 
 #include "ck/ck.hpp"
 #include "ck/utility/reduction_enums.hpp"
-#include "ck/tensor_operation/gpu/device/reduction_operator_mapping.hpp"
 #include "ck/tensor_operation/gpu/device/device_reduce_multiblock.hpp"
+#include "ck/tensor_operation/gpu/device/reduction_operator_mapping.hpp"
 
+#include "ck/library/utility/algorithm.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
 #include "ck/library/utility/host_common_util.hpp"
 #include "ck/library/utility/host_reduction.hpp"
+#include "ck/library/utility/ranges.hpp"
 
 #include "reduce_example_common.hpp"
 
@@ -156,11 +158,11 @@ int reduce_blockwise_impl(bool do_verification,
     Tensor<int> out_indices_ref(outLengths);
     Tensor<int> out_indices(outLengths);
 
-    auto inStrides  = in.mDesc.GetStrides();
-    auto outStrides = out.mDesc.GetStrides();
+    auto inStrides  = in.GetStrides();
+    auto outStrides = out.GetStrides();
 
-    size_t invariant_total_length = out.mDesc.GetElementSize();
-    size_t reduce_total_length    = in.mDesc.GetElementSize() / invariant_total_length;
+    size_t invariant_total_length = out.GetElementSize();
+    size_t reduce_total_length    = in.GetElementSize() / invariant_total_length;
 
     std::size_t num_thread = 1;
 
@@ -187,42 +189,43 @@ int reduce_blockwise_impl(bool do_verification,
         }
 
         if(beta != 0.0f)
-            for(size_t i = 0; i < out_ref.mDesc.GetElementSpaceSize(); i++)
-                out.mData[i] = out_ref.mData[i];
+        {
+            ck::ranges::copy(out_ref, out.begin());
+        }
     };
 
     // these buffers are usually provided by the user application
-    DeviceMem in_dev(sizeof(InOutDataTypeInDevice) * in.mDesc.GetElementSpaceSize());
-    DeviceMem out_dev(sizeof(InOutDataTypeInDevice) * out.mDesc.GetElementSpaceSize());
+    DeviceMem in_dev(in.GetMemorySize());
+    DeviceMem out_dev(out.GetMemorySize());
 
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
     if(std::is_same<InOutDataType, int4_t>::value)
     {
-        std::vector<InOutDataTypeInDevice> tmp_buf(in.mData.size());
+        std::vector<InOutDataTypeInDevice> tmp_buf(in.size());
 
-        std::copy_n(in.mData.data(), in.mData.size(), tmp_buf.data());
+        std::copy_n(in.data(), in.size(), tmp_buf.data());
         in_dev.ToDevice(tmp_buf.data());
     }
     else
 #endif
-        in_dev.ToDevice(in.mData.data());
+        in_dev.ToDevice(in.data());
 
     if(beta != 0.0f)
     {
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
         if(std::is_same<InOutDataType, int4_t>::value)
         {
-            std::vector<InOutDataTypeInDevice> tmp_buf(in.mData.size());
+            std::vector<InOutDataTypeInDevice> tmp_buf(in.size());
 
-            std::copy_n(out.mData.data(), out.mData.size(), tmp_buf.data());
+            std::copy_n(out.data(), out.size(), tmp_buf.data());
             out_dev.ToDevice(tmp_buf.data());
         }
         else
 #endif
-            out_dev.ToDevice(out.mData.data());
+            out_dev.ToDevice(out.data());
     };
 
-    size_t indicesSizeInBytes = OutputIndex ? out.mDesc.GetElementSize() * sizeof(int32_t) : 0;
+    size_t indicesSizeInBytes = OutputIndex ? out.GetElementSize() * sizeof(int32_t) : 0;
 
     DeviceMem out_index_dev(indicesSizeInBytes);
 
@@ -245,33 +248,25 @@ int reduce_blockwise_impl(bool do_verification,
                       NumReduceDim,
                       PropagateNan,
                       OutputIndex>
-            hostReduce(in.mDesc, out_ref.mDesc, invariantDims, reduceDims);
+            hostReduce(in.GetDesc(), out_ref.GetDesc(), invariantDims, reduceDims);
 
         hostReduce.Run(alpha,
-                       in.mData.data(),
+                       in.data(),
                        beta,
-                       out_ref.mData.data(),
-                       out_indices_ref.mData.data(),
+                       out_ref.data(),
+                       out_indices_ref.data(),
                        in_elementwise_op,
                        acc_elementwise_op);
     };
 
-    std::vector<ck::index_t> i_inLengths;
-    std::vector<ck::index_t> i_inStrides;
-    std::vector<ck::index_t> i_outLengths;
-    std::vector<ck::index_t> i_outStrides;
-
-    i_inLengths.assign(inLengths.begin(), inLengths.end());
-    i_inStrides.assign(inStrides.begin(), inStrides.end());
-    i_outLengths.assign(outLengths.begin(), outLengths.end());
-    i_outStrides.assign(outStrides.begin(), outStrides.end());
+    using Indices = std::vector<ck::index_t>;
 
     auto reduce = DeviceReduceInstance{};
 
-    auto argument_ptr = reduce.MakeArgumentPointer(i_inLengths,
-                                                   i_inStrides,
-                                                   i_outLengths,
-                                                   i_outStrides,
+    auto argument_ptr = reduce.MakeArgumentPointer(ck::ranges::to<Indices>(inLengths),
+                                                   ck::ranges::to<Indices>(inStrides),
+                                                   ck::ranges::to<Indices>(outLengths),
+                                                   ck::ranges::to<Indices>(outStrides),
                                                    reduceDims,
                                                    alpha,
                                                    beta,
@@ -312,22 +307,22 @@ int reduce_blockwise_impl(bool do_verification,
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
         if(std::is_same<InOutDataType, int4_t>::value)
         {
-            std::vector<InOutDataTypeInDevice> tmp_buf(out.mData.size());
+            std::vector<InOutDataTypeInDevice> tmp_buf(out.size());
 
             out_dev.FromDevice(tmp_buf.data());
 
-            std::copy_n(tmp_buf.data(), out.mData.size(), out.mData.data());
+            std::copy_n(tmp_buf.data(), out.size(), out.data());
         }
         else
 #endif
-            out_dev.FromDevice(out.mData.data());
+            out_dev.FromDevice(out.data());
 
-        pass = pass && ck::utils::check_err(out.mData, out_ref.mData);
+        pass = pass && ck::utils::check_err(out, out_ref);
 
         if(OutputIndex)
         {
-            out_index_dev.FromDevice(out_indices.mData.data());
-            pass = pass && ck::utils::check_err(out_indices.mData, out_indices_ref.mData);
+            out_index_dev.FromDevice(out_indices.data());
+            pass = pass && ck::utils::check_err(out_indices, out_indices_ref);
         };
     };
 

--- a/example/14_gemm_xdl_requant_relu_requant/gemm_xdl_requant_relu_requant_int8.cpp
+++ b/example/14_gemm_xdl_requant_relu_requant/gemm_xdl_requant_relu_requant_int8.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
 #include <iostream>
 #include <numeric>
 #include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
@@ -12,11 +12,12 @@
 #include "ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/literals.hpp"
 
 struct RequantReluRequant
 {
@@ -155,17 +156,17 @@ int main(int argc, char* argv[])
         exit(0);
     }
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-            if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
+            if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -174,9 +175,9 @@ int main(int argc, char* argv[])
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "c_m_n: " << c_m_n_host_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "c_m_n: " << c_m_n_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -190,12 +191,12 @@ int main(int argc, char* argv[])
         b_k_n.GenerateTensorValue(GeneratorTensor_3<BDataType>{-0.5, 0.5});
     }
 
-    DeviceMem a_m_k_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_k_n_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_m_n_device_buf(sizeof(CDataType) * c_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_m_k_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_k_n_device_buf(b_k_n.GetMemorySize());
+    DeviceMem c_m_n_device_buf(c_m_n_device_result.GetMemorySize());
 
-    a_m_k_device_buf.ToDevice(a_m_k.mData.data());
-    b_k_n_device_buf.ToDevice(b_k_n.mData.data());
+    a_m_k_device_buf.ToDevice(a_m_k.data());
+    b_k_n_device_buf.ToDevice(b_k_n.data());
 
     auto a_element_op = PassThrough{};
     auto b_element_op = PassThrough{};
@@ -204,9 +205,9 @@ int main(int argc, char* argv[])
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-                                      static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-                                      static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
+    auto argument = gemm.MakeArgument(a_m_k_device_buf.GetDeviceBuffer(),
+                                      b_k_n_device_buf.GetDeviceBuffer(),
+                                      c_m_n_device_buf.GetDeviceBuffer(),
                                       M,
                                       N,
                                       K,
@@ -237,7 +238,7 @@ int main(int argc, char* argv[])
     std::cout << "Perf: " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
               << gemm.GetTypeString() << std::endl;
 
-    c_m_n_device_buf.FromDevice(c_m_n_device_result.mData.data());
+    c_m_n_device_buf.FromDevice(c_m_n_device_result.data());
 
     if(do_verification)
     {
@@ -249,7 +250,7 @@ int main(int argc, char* argv[])
 
         ref_invoker.Run(ref_argument);
 
-        return ck::utils::check_err(c_m_n_device_result.mData, c_m_n_host_result.mData) ? 0 : 1;
+        return ck::utils::check_err(c_m_n_device_result, c_m_n_host_result) ? 0 : 1;
     }
 
     return 0;

--- a/example/15_grouped_gemm/common.hpp
+++ b/example/15_grouped_gemm/common.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <cstdlib>
+#include <initializer_list>
+#include <iostream>
+#include <numeric>
+
+#include "ck/ck.hpp"
+#include "ck/tensor_operation/gpu/device/device_grouped_gemm_xdl.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/literals.hpp"
+
+template <ck::index_t... Is>
+using S = ck::Sequence<Is...>;
+
+using BF16 = ck::bhalf_t;
+using F16  = ck::half_t;
+using F32  = float;
+
+using Row = ck::tensor_layout::gemm::RowMajor;
+using Col = ck::tensor_layout::gemm::ColumnMajor;
+
+using PassThrough = ck::tensor_operation::element_wise::PassThrough;

--- a/example/15_grouped_gemm/grouped_gemm_xdl_bfp16.cpp
+++ b/example/15_grouped_gemm/grouped_gemm_xdl_bfp16.cpp
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_grouped_gemm_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using BF16 = ck::bhalf_t;
-using F32  = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = BF16;
 using BDataType        = BF16;

--- a/example/15_grouped_gemm/grouped_gemm_xdl_fp16.cpp
+++ b/example/15_grouped_gemm/grouped_gemm_xdl_fp16.cpp
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_grouped_gemm_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F16 = ck::half_t;
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = F16;
 using BDataType        = F16;

--- a/example/15_grouped_gemm/grouped_gemm_xdl_fp32.cpp
+++ b/example/15_grouped_gemm/grouped_gemm_xdl_fp32.cpp
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_grouped_gemm_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F16 = ck::half_t;
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = F32;
 using BDataType        = F32;

--- a/example/15_grouped_gemm/grouped_gemm_xdl_int4.cpp
+++ b/example/15_grouped_gemm/grouped_gemm_xdl_int4.cpp
@@ -1,30 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_grouped_gemm_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = ck::int4_t;
 using BDataType        = ck::int4_t;

--- a/example/15_grouped_gemm/grouped_gemm_xdl_int8.cpp
+++ b/example/15_grouped_gemm/grouped_gemm_xdl_int8.cpp
@@ -1,30 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_grouped_gemm_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = int8_t;
 using BDataType        = int8_t;

--- a/example/15_grouped_gemm/run_grouped_gemm_example.inc
+++ b/example/15_grouped_gemm/run_grouped_gemm_example.inc
@@ -50,17 +50,17 @@ bool run_grouped_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
         gemm_descs.push_back({M, N, K, stride_A, stride_B, stride_C, {}});
     }
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-            if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
+            if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -90,27 +90,27 @@ bool run_grouped_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
 
     for(std::size_t i = 0; i < gemm_descs.size(); i++)
     {
-        a_tensors.push_back(Tensor<ADataType>(f_host_tensor_descriptor(
-            gemm_descs[i].M_, gemm_descs[i].K_, gemm_descs[i].stride_A_, ALayout{})));
-        b_tensors.push_back(Tensor<BDataType>(f_host_tensor_descriptor(
-            gemm_descs[i].K_, gemm_descs[i].N_, gemm_descs[i].stride_B_, BLayout{})));
-        c_host_tensors.push_back(Tensor<EDataType>(f_host_tensor_descriptor(
-            gemm_descs[i].M_, gemm_descs[i].N_, gemm_descs[i].stride_C_, ELayout{})));
+        a_tensors.emplace_back(f_host_tensor_descriptor(
+            gemm_descs[i].M_, gemm_descs[i].K_, gemm_descs[i].stride_A_, ALayout{}));
+        b_tensors.emplace_back(f_host_tensor_descriptor(
+            gemm_descs[i].K_, gemm_descs[i].N_, gemm_descs[i].stride_B_, BLayout{}));
+        c_host_tensors.emplace_back(f_host_tensor_descriptor(
+            gemm_descs[i].M_, gemm_descs[i].N_, gemm_descs[i].stride_C_, ELayout{}));
 #ifdef BUILD_INT4_EXAMPLE
-        c_device_tensors.push_back(Tensor<KernelEDataType>(f_host_tensor_descriptor(
-            gemm_descs[i].M_, gemm_descs[i].N_, gemm_descs[i].stride_C_, ELayout{})));
+        c_device_tensors.emplace_back(f_host_tensor_descriptor(
+            gemm_descs[i].M_, gemm_descs[i].N_, gemm_descs[i].stride_C_, ELayout{}));
 #else
-        c_device_tensors.push_back(Tensor<EDataType>(f_host_tensor_descriptor(
-            gemm_descs[i].M_, gemm_descs[i].N_, gemm_descs[i].stride_C_, ELayout{})));
+        c_device_tensors.emplace_back(f_host_tensor_descriptor(
+            gemm_descs[i].M_, gemm_descs[i].N_, gemm_descs[i].stride_C_, ELayout{}));
 #endif
-        std::cout << "gemm[" << i << "] a_m_k: " << a_tensors[i].mDesc
-                  << " b_k_n: " << b_tensors[i].mDesc << " c_m_n: " << c_device_tensors[i].mDesc
-                  << std::endl;
+        std::cout << "gemm[" << i << "] a_m_k: " << a_tensors[i].GetDesc()
+                  << " b_k_n: " << b_tensors[i].GetDesc()
+                  << " c_m_n: " << c_device_tensors[i].GetDesc() << std::endl;
 
         flop += std::size_t(2) * gemm_descs[i].M_ * gemm_descs[i].K_ * gemm_descs[i].N_;
-        num_btype += sizeof(ADataType) * a_tensors[i].mDesc.GetElementSize() +
-                     sizeof(BDataType) * b_tensors[i].mDesc.GetElementSize() +
-                     sizeof(EDataType) * c_device_tensors[i].mDesc.GetElementSize();
+        num_btype += sizeof(ADataType) * a_tensors[i].GetElementSize() +
+                     sizeof(BDataType) * b_tensors[i].GetElementSize() +
+                     sizeof(EDataType) * c_device_tensors[i].GetElementSize();
 
         switch(config.init_method)
         {
@@ -131,22 +131,20 @@ bool run_grouped_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
 
     for(std::size_t i = 0; i < gemm_descs.size(); i++)
     {
-        a_tensors_device.emplace_back(std::make_unique<DeviceMem>(
-            sizeof(ADataType) * a_tensors[i].mDesc.GetElementSpaceSize()));
-        b_tensors_device.emplace_back(std::make_unique<DeviceMem>(
-            sizeof(BDataType) * b_tensors[i].mDesc.GetElementSpaceSize()));
-        c_tensors_device.emplace_back(std::make_unique<DeviceMem>(
-            sizeof(EDataType) * c_device_tensors[i].mDesc.GetElementSpaceSize()));
+        a_tensors_device.emplace_back(std::make_unique<DeviceMem>(a_tensors[i].GetMemorySize()));
+        b_tensors_device.emplace_back(std::make_unique<DeviceMem>(b_tensors[i].GetMemorySize()));
+        c_tensors_device.emplace_back(
+            std::make_unique<DeviceMem>(c_device_tensors[i].GetMemorySize()));
 
 #ifdef BUILD_INT4_EXAMPLE
         const Tensor<KernelADataType> a_converted(a_tensors[i]);
         const Tensor<KernelBDataType> b_converted(b_tensors[i]);
 
-        a_tensors_device[i]->ToDevice(a_converted.mData.data());
-        b_tensors_device[i]->ToDevice(b_converted.mData.data());
+        a_tensors_device[i]->ToDevice(a_converted.data());
+        b_tensors_device[i]->ToDevice(b_converted.data());
 #else
-        a_tensors_device[i]->ToDevice(a_tensors[i].mData.data());
-        b_tensors_device[i]->ToDevice(b_tensors[i].mData.data());
+        a_tensors_device[i]->ToDevice(a_tensors[i].data());
+        b_tensors_device[i]->ToDevice(b_tensors[i].data());
 #endif
 
         p_a.push_back(a_tensors_device[i]->GetDeviceBuffer());
@@ -193,7 +191,7 @@ bool run_grouped_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
 
         for(std::size_t i = 0; i < gemm_descs.size(); i++)
         {
-            c_tensors_device[i]->FromDevice(c_device_tensors[i].mData.data());
+            c_tensors_device[i]->FromDevice(c_device_tensors[i].data());
             auto ref_gemm    = ReferenceGemmInstance{};
             auto ref_invoker = ref_gemm.MakeInvoker();
 
@@ -208,10 +206,10 @@ bool run_grouped_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
 
 #ifdef BUILD_INT4_EXAMPLE
             const Tensor<EDataType> c_device_result_converted(c_device_tensors[i]);
-            pass &= ck::utils::check_err(c_device_result_converted.mData, c_host_tensors[i].mData);
+            pass &= ck::utils::check_err(c_device_result_converted, c_host_tensors[i]);
 
 #else
-            pass &= ck::utils::check_err(c_device_tensors[i].mData, c_host_tensors[i].mData);
+            pass &= ck::utils::check_err(c_device_tensors[i], c_host_tensors[i]);
 #endif
         }
     }

--- a/example/16_gemm_multi_d_multi_reduces/gemm_reduce_xdl_common.hpp
+++ b/example/16_gemm_multi_d_multi_reduces/gemm_reduce_xdl_common.hpp
@@ -134,21 +134,19 @@ auto run_gemm_reduce_max_xdl(ck::index_t M,
     {
     case 0: break;
     case 1:
-        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-5.f, 5.f}(a_m_k.begin(),
-                                                                             a_m_k.end());
-        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-5.f, 5.f}(b_k_n.begin(),
-                                                                             b_k_n.end());
+        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-5.f, 5.f}(a_m_k);
+        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-5.f, 5.f}(b_k_n);
         break;
     default:
-        ck::utils::FillUniformDistribution<ADataType>{-1.f, 1.f}(a_m_k.begin(), a_m_k.end());
-        ck::utils::FillUniformDistribution<BDataType>{-1.f, 1.f}(b_k_n.begin(), b_k_n.end());
+        ck::utils::FillUniformDistribution<ADataType>{-1.f, 1.f}(a_m_k);
+        ck::utils::FillUniformDistribution<BDataType>{-1.f, 1.f}(b_k_n);
         break;
     }
 
-    DeviceMem a_device_buf(sizeof(ADataKernelType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataKernelType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataKernelType) * e_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem r0_device_buf(sizeof(R0DataType) * r0_m.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem e_device_buf(e_m_n.GetMemorySize());
+    DeviceMem r0_device_buf(r0_m.GetMemorySize());
 
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
     if constexpr(std::is_same_v<ADataType, ck::int4_t>)
@@ -156,14 +154,14 @@ auto run_gemm_reduce_max_xdl(ck::index_t M,
         Tensor<ADataKernelType> a_m_k_converted = a_m_k.template CopyAsType<ADataKernelType>();
         Tensor<BDataKernelType> b_k_n_converted = b_k_n.template CopyAsType<BDataKernelType>();
 
-        a_device_buf.ToDevice(a_m_k_converted.mData.data());
-        b_device_buf.ToDevice(b_k_n_converted.mData.data());
+        a_device_buf.ToDevice(a_m_k_converted.data());
+        b_device_buf.ToDevice(b_k_n_converted.data());
     }
     else
 #endif // CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
     {
-        a_device_buf.ToDevice(a_m_k.mData.data());
-        b_device_buf.ToDevice(b_k_n.mData.data());
+        a_device_buf.ToDevice(a_m_k.data());
+        b_device_buf.ToDevice(b_k_n.data());
     }
 
     auto a_element_op   = AElementOp{};
@@ -210,8 +208,8 @@ auto run_gemm_reduce_max_xdl(ck::index_t M,
     {
         auto I0 = ck::Number<0>{};
 
-        Tensor<ReduceAccDataType> e_m_n_host(e_m_n.mDesc);
-        Tensor<R0DataType> r0_m_host(r0_m.mDesc);
+        Tensor<ReduceAccDataType> e_m_n_host(e_m_n.GetDesc());
+        Tensor<R0DataType> r0_m_host(r0_m.GetDesc());
 
         auto ref_gemm    = ReferenceGemmInstance{};
         auto ref_invoker = ref_gemm.MakeInvoker();
@@ -236,15 +234,15 @@ auto run_gemm_reduce_max_xdl(ck::index_t M,
             r0_m_host(m) = ck::type_convert<R0DataType>(reduce0_acc);
         }
 
-        e_device_buf.FromDevice(e_m_n.mData.data());
+        e_device_buf.FromDevice(e_m_n.data());
         Tensor<EDataType> e_m_n_host_converted(e_m_n_host);
 
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
         if constexpr(std::is_same_v<ADataType, ck::int4_t>)
         {
             Tensor<EDataType> e_m_n_device_converted(e_m_n);
-            pass = ck::utils::check_err(e_m_n_device_converted.mData,
-                                        e_m_n_host_converted.mData,
+            pass = ck::utils::check_err(e_m_n_device_converted,
+                                        e_m_n_host_converted,
                                         "Error: Incorrect results c",
                                         1e-2,
                                         1e-2);
@@ -253,12 +251,11 @@ auto run_gemm_reduce_max_xdl(ck::index_t M,
 #endif // CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
         {
             pass = ck::utils::check_err(
-                e_m_n.mData, e_m_n_host_converted.mData, "Error: Incorrect results c", 1e-2, 1e-2);
+                e_m_n, e_m_n_host_converted, "Error: Incorrect results c", 1e-2, 1e-2);
         }
 
-        r0_device_buf.FromDevice(r0_m.mData.data());
-        pass &= ck::utils::check_err(
-            r0_m.mData, r0_m_host.mData, "Error: Incorrect results d0", 1e-2, 1e-2);
+        r0_device_buf.FromDevice(r0_m.data());
+        pass &= ck::utils::check_err(r0_m, r0_m_host, "Error: Incorrect results d0", 1e-2, 1e-2);
 
         if(pass)
         {
@@ -339,22 +336,20 @@ bool run_gemm_reduce_mean_meansquare_xdl(ck::index_t M,
     {
     case 0: break;
     case 1:
-        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-5.f, 5.f}(a_m_k.begin(),
-                                                                             a_m_k.end());
-        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-5.f, 5.f}(b_k_n.begin(),
-                                                                             b_k_n.end());
+        ck::utils::FillUniformDistributionIntegerValue<ADataType>{-5.f, 5.f}(a_m_k);
+        ck::utils::FillUniformDistributionIntegerValue<BDataType>{-5.f, 5.f}(b_k_n);
         break;
     default:
-        ck::utils::FillUniformDistribution<ADataType>{-1.f, 1.f}(a_m_k.begin(), a_m_k.end());
-        ck::utils::FillUniformDistribution<BDataType>{-1.f, 1.f}(b_k_n.begin(), b_k_n.end());
+        ck::utils::FillUniformDistribution<ADataType>{-1.f, 1.f}(a_m_k);
+        ck::utils::FillUniformDistribution<BDataType>{-1.f, 1.f}(b_k_n);
         break;
     }
 
-    DeviceMem a_device_buf(sizeof(ADataKernelType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataKernelType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataKernelType) * e_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem r0_device_buf(sizeof(R0DataType) * r0_m.mDesc.GetElementSpaceSize());
-    DeviceMem r1_device_buf(sizeof(R1DataType) * r1_m.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem e_device_buf(e_m_n.GetMemorySize());
+    DeviceMem r0_device_buf(r0_m.GetMemorySize());
+    DeviceMem r1_device_buf(r1_m.GetMemorySize());
 
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
     if constexpr(std::is_same_v<ADataType, ck::int4_t>)
@@ -362,14 +357,14 @@ bool run_gemm_reduce_mean_meansquare_xdl(ck::index_t M,
         Tensor<ADataKernelType> a_m_k_converted = a_m_k.template CopyAsType<ADataKernelType>();
         Tensor<BDataKernelType> b_k_n_converted = b_k_n.template CopyAsType<BDataKernelType>();
 
-        a_device_buf.ToDevice(a_m_k_converted.mData.data());
-        b_device_buf.ToDevice(b_k_n_converted.mData.data());
+        a_device_buf.ToDevice(a_m_k_converted.data());
+        b_device_buf.ToDevice(b_k_n_converted.data());
     }
     else
 #endif // CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
     {
-        a_device_buf.ToDevice(a_m_k.mData.data());
-        b_device_buf.ToDevice(b_k_n.mData.data());
+        a_device_buf.ToDevice(a_m_k.data());
+        b_device_buf.ToDevice(b_k_n.data());
     }
 
     auto a_element_op   = AElementOp{};
@@ -418,9 +413,9 @@ bool run_gemm_reduce_mean_meansquare_xdl(ck::index_t M,
         auto I0 = ck::Number<0>{};
         auto I1 = ck::Number<1>{};
 
-        Tensor<ReduceAccDataType> e_m_n_host(e_m_n.mDesc);
-        Tensor<R0DataType> r0_m_host(r0_m.mDesc);
-        Tensor<R1DataType> r1_m_host(r1_m.mDesc);
+        Tensor<ReduceAccDataType> e_m_n_host(e_m_n.GetDesc());
+        Tensor<R0DataType> r0_m_host(r0_m.GetDesc());
+        Tensor<R1DataType> r1_m_host(r1_m.GetDesc());
 
         auto ref_gemm    = ReferenceGemmInstance{};
         auto ref_invoker = ref_gemm.MakeInvoker();
@@ -453,15 +448,15 @@ bool run_gemm_reduce_mean_meansquare_xdl(ck::index_t M,
             r0_m_host(m) = ck::type_convert<R0DataType>(reduce0_acc);
             r1_m_host(m) = ck::type_convert<R1DataType>(reduce1_acc);
         }
-        e_device_buf.FromDevice(e_m_n.mData.data());
+        e_device_buf.FromDevice(e_m_n.data());
         Tensor<EDataType> e_m_n_host_converted(e_m_n_host);
 
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
         if constexpr(std::is_same_v<ADataType, ck::int4_t>)
         {
             Tensor<EDataType> e_m_n_device_converted(e_m_n);
-            pass = ck::utils::check_err(e_m_n_device_converted.mData,
-                                        e_m_n_host_converted.mData,
+            pass = ck::utils::check_err(e_m_n_device_converted,
+                                        e_m_n_host_converted,
                                         "Error: Incorrect results c",
                                         1e-2,
                                         1e-2);
@@ -470,16 +465,14 @@ bool run_gemm_reduce_mean_meansquare_xdl(ck::index_t M,
 #endif // CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
         {
             pass = ck::utils::check_err(
-                e_m_n.mData, e_m_n_host_converted.mData, "Error: Incorrect results c", 1e-2, 1e-2);
+                e_m_n, e_m_n_host_converted, "Error: Incorrect results c", 1e-2, 1e-2);
         }
 
-        r0_device_buf.FromDevice(r0_m.mData.data());
-        r1_device_buf.FromDevice(r1_m.mData.data());
+        r0_device_buf.FromDevice(r0_m.data());
+        r1_device_buf.FromDevice(r1_m.data());
 
-        pass &= ck::utils::check_err(
-            r0_m.mData, r0_m_host.mData, "Error: Incorrect results d0", 1e-2, 1e-2);
-        pass &= ck::utils::check_err(
-            r1_m.mData, r1_m_host.mData, "Error: Incorrect results d1", 1e-2, 1e-2);
+        pass &= ck::utils::check_err(r0_m, r0_m_host, "Error: Incorrect results d0", 1e-2, 1e-2);
+        pass &= ck::utils::check_err(r1_m, r1_m_host, "Error: Incorrect results d1", 1e-2, 1e-2);
 
         if(pass)
         {

--- a/example/18_batched_gemm_reduce/batched_gemm_reduce_xdl_fp16.cpp
+++ b/example/18_batched_gemm_reduce/batched_gemm_reduce_xdl_fp16.cpp
@@ -150,13 +150,13 @@ int main(int argc, char* argv[])
 
     Tensor<CDataType> c_g_m_n_host_result(
         f_host_tensor_descriptor(BatchCount, M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> d0_g_m_host_result(HostTensorDescriptor({BatchCount, M}));
-    Tensor<ReduceDataType> d1_g_m_host_result(HostTensorDescriptor({BatchCount, M}));
+    Tensor<ReduceDataType> d0_g_m_host_result({BatchCount, M});
+    Tensor<ReduceDataType> d1_g_m_host_result({BatchCount, M});
 
     Tensor<CDataType> c_g_m_n_device_result(
         f_host_tensor_descriptor(BatchCount, M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> d0_g_m_device_result(HostTensorDescriptor({BatchCount, M}));
-    Tensor<ReduceDataType> d1_g_m_device_result(HostTensorDescriptor({BatchCount, M}));
+    Tensor<ReduceDataType> d0_g_m_device_result({BatchCount, M});
+    Tensor<ReduceDataType> d1_g_m_device_result({BatchCount, M});
 
     std::cout << "a_g_m_k: " << a_g_m_k.GetDesc() << std::endl;
     std::cout << "b_g_k_n: " << b_g_k_n.GetDesc() << std::endl;

--- a/example/21_gemm_layernorm/gemm_bias_relu_add_layernorm_xdl_fp16.cpp
+++ b/example/21_gemm_layernorm/gemm_bias_relu_add_layernorm_xdl_fp16.cpp
@@ -1,23 +1,24 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/device_gemm_multiple_d_multiple_r_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/device/device_elementwise.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/literals.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -108,21 +109,20 @@ using DeviceNormalizeInstance = ck::tensor_operation::device::DeviceElementwise<
     ck::Sequence<8>>;            // scalarPerVector: y(layerNorm_out)
 
 auto f_host_tensor_descriptor1d = [](std::size_t len, std::size_t stride) {
-    return HostTensorDescriptor(std::vector<std::size_t>({len}),
-                                std::vector<std::size_t>({stride}));
+    return HostTensorDescriptor({len}, {stride});
 };
+
+using namespace ck::literals;
 
 auto f_host_tensor_descriptor2d =
     [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-        if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
+        if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                        std::vector<std::size_t>({stride, 1}));
+            return HostTensorDescriptor({row, col}, {stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                        std::vector<std::size_t>({1, stride}));
+            return HostTensorDescriptor({row, col}, {1_uz, stride});
         }
     };
 
@@ -264,25 +264,23 @@ int main()
     gamma_n.GenerateTensorValue(GeneratorTensor_3<GammaDataType>{-1, 1});
     beta_n.GenerateTensorValue(GeneratorTensor_3<BetaDataType>{-1, 1});
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem bias_device_buf(sizeof(D0DataType) * bias_n.mDesc.GetElementSpaceSize());
-    DeviceMem d1_device_buf(sizeof(D1DataType) * d1_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) * e_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem r0_Mean_device_buf(sizeof(R0DataType) * r0_Mean_m.mDesc.GetElementSpaceSize());
-    DeviceMem r1_MeanSquare_device_buf(sizeof(R1DataType) *
-                                       r1_MeanSquare_m.mDesc.GetElementSpaceSize());
-    DeviceMem gamma_device_buf(sizeof(GammaDataType) * gamma_n.mDesc.GetElementSpaceSize());
-    DeviceMem beta_device_buf(sizeof(BetaDataType) * beta_n.mDesc.GetElementSpaceSize());
-    DeviceMem layerNorm_device_buf(sizeof(LayerNormOutDataType) *
-                                   layerNorm_m_n.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem bias_device_buf(bias_n.GetMemorySize());
+    DeviceMem d1_device_buf(d1_m_n.GetMemorySize());
+    DeviceMem e_device_buf(e_m_n.GetMemorySize());
+    DeviceMem r0_Mean_device_buf(r0_Mean_m.GetMemorySize());
+    DeviceMem r1_MeanSquare_device_buf(r1_MeanSquare_m.GetMemorySize());
+    DeviceMem gamma_device_buf(gamma_n.GetMemorySize());
+    DeviceMem beta_device_buf(beta_n.GetMemorySize());
+    DeviceMem layerNorm_device_buf(layerNorm_m_n.GetMemorySize());
 
-    a_device_buf.ToDevice(a_m_k.mData.data());
-    b_device_buf.ToDevice(b_k_n.mData.data());
-    bias_device_buf.ToDevice(bias_n.mData.data());
-    d1_device_buf.ToDevice(d1_m_n.mData.data());
-    gamma_device_buf.ToDevice(gamma_n.mData.data());
-    beta_device_buf.ToDevice(beta_n.mData.data());
+    a_device_buf.ToDevice(a_m_k.data());
+    b_device_buf.ToDevice(b_k_n.data());
+    bias_device_buf.ToDevice(bias_n.data());
+    d1_device_buf.ToDevice(d1_m_n.data());
+    gamma_device_buf.ToDevice(gamma_n.data());
+    beta_device_buf.ToDevice(beta_n.data());
 
     auto a_element_op   = AElementOp{};
     auto b_element_op   = BElementOp{};
@@ -371,9 +369,9 @@ int main()
                             M,
                             N);
 
-        layerNorm_device_buf.FromDevice(layerNorm_m_n.mData.data());
-        pass &= ck::utils::check_err(layerNorm_m_n.mData,
-                                     host_layerNorm_m_n.mData,
+        layerNorm_device_buf.FromDevice(layerNorm_m_n.data());
+        pass &= ck::utils::check_err(layerNorm_m_n,
+                                     host_layerNorm_m_n,
                                      "Error: Incorrect results layerNorm_m_n",
                                      1e-2,
                                      1e-2);

--- a/example/21_gemm_layernorm/gemm_layernorm_xdl_fp16.cpp
+++ b/example/21_gemm_layernorm/gemm_layernorm_xdl_fp16.cpp
@@ -1,23 +1,24 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/device_gemm_multiple_d_multiple_r_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/device/device_elementwise.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/literals.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -107,21 +108,20 @@ using DeviceNormalizeInstance = ck::tensor_operation::device::DeviceElementwise<
     ck::Sequence<8>>;            // scalarPerVector: y(layerNorm_out)
 
 auto f_host_tensor_descriptor1d = [](std::size_t len, std::size_t stride) {
-    return HostTensorDescriptor(std::vector<std::size_t>({len}),
-                                std::vector<std::size_t>({stride}));
+    return HostTensorDescriptor({len}, {stride});
 };
+
+using namespace ck::literals;
 
 auto f_host_tensor_descriptor2d =
     [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-        if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
+        if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                        std::vector<std::size_t>({stride, 1}));
+            return HostTensorDescriptor({row, col}, {stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                        std::vector<std::size_t>({1, stride}));
+            return HostTensorDescriptor({row, col}, {1_uz, stride});
         }
     };
 
@@ -243,21 +243,19 @@ int main()
     gamma_n.GenerateTensorValue(GeneratorTensor_3<GammaDataType>{-1, 1});
     beta_n.GenerateTensorValue(GeneratorTensor_3<BetaDataType>{-1, 1});
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) * e_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem r0_Mean_device_buf(sizeof(R0DataType) * r0_Mean_m.mDesc.GetElementSpaceSize());
-    DeviceMem r1_MeanSquare_device_buf(sizeof(R1DataType) *
-                                       r1_MeanSquare_m.mDesc.GetElementSpaceSize());
-    DeviceMem gamma_device_buf(sizeof(GammaDataType) * gamma_n.mDesc.GetElementSpaceSize());
-    DeviceMem beta_device_buf(sizeof(BetaDataType) * beta_n.mDesc.GetElementSpaceSize());
-    DeviceMem layerNorm_device_buf(sizeof(LayerNormOutDataType) *
-                                   layerNorm_m_n.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem e_device_buf(e_m_n.GetMemorySize());
+    DeviceMem r0_Mean_device_buf(r0_Mean_m.GetMemorySize());
+    DeviceMem r1_MeanSquare_device_buf(r1_MeanSquare_m.GetMemorySize());
+    DeviceMem gamma_device_buf(gamma_n.GetMemorySize());
+    DeviceMem beta_device_buf(beta_n.GetMemorySize());
+    DeviceMem layerNorm_device_buf(layerNorm_m_n.GetMemorySize());
 
-    a_device_buf.ToDevice(a_m_k.mData.data());
-    b_device_buf.ToDevice(b_k_n.mData.data());
-    gamma_device_buf.ToDevice(gamma_n.mData.data());
-    beta_device_buf.ToDevice(beta_n.mData.data());
+    a_device_buf.ToDevice(a_m_k.data());
+    b_device_buf.ToDevice(b_k_n.data());
+    gamma_device_buf.ToDevice(gamma_n.data());
+    beta_device_buf.ToDevice(beta_n.data());
 
     auto a_element_op   = AElementOp{};
     auto b_element_op   = BElementOp{};
@@ -345,12 +343,9 @@ int main()
                             M,
                             N);
 
-        layerNorm_device_buf.FromDevice(layerNorm_m_n.mData.data());
-        pass &= ck::utils::check_err(layerNorm_m_n.mData,
-                                     host_layerNorm_m_n.mData,
-                                     "Error: Incorrect results d1",
-                                     1e-3,
-                                     1e-3);
+        layerNorm_device_buf.FromDevice(layerNorm_m_n.data());
+        pass &= ck::utils::check_err(
+            layerNorm_m_n, host_layerNorm_m_n, "Error: Incorrect results d1", 1e-3, 1e-3);
     }
 
     {

--- a/example/21_gemm_layernorm/gemm_xdl_layernorm_single_kernel_fp16.cpp
+++ b/example/21_gemm_layernorm/gemm_xdl_layernorm_single_kernel_fp16.cpp
@@ -151,10 +151,10 @@ int main(int argc, char* argv[])
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
     Tensor<AccDataType> acc_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
-    Tensor<C0DataType> c0_n_bias(HostTensorDescriptor(std::vector<size_t>({size_t(N)})));
+    Tensor<C0DataType> c0_n_bias({N});
     Tensor<C0DataType> c0_m_n_add(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
-    Tensor<C0DataType> c0_n_gamma(HostTensorDescriptor(std::vector<size_t>({size_t(N)})));
-    Tensor<C0DataType> c0_n_beta(HostTensorDescriptor(std::vector<size_t>({size_t(N)})));
+    Tensor<C0DataType> c0_n_gamma({N});
+    Tensor<C0DataType> c0_n_beta({N});
 
     std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
     std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;

--- a/example/24_batched_gemm/batched_gemm_xdl_bfp16.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_bfp16.cpp
@@ -1,31 +1,7 @@
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_multi_d_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using BF16 = ck::bhalf_t;
-using F32  = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = BF16;
 using BDataType        = BF16;

--- a/example/24_batched_gemm/batched_gemm_xdl_fp16.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_fp16.cpp
@@ -1,31 +1,7 @@
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_multi_d_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F16 = ck::half_t;
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = F16;
 using BDataType        = F16;

--- a/example/24_batched_gemm/batched_gemm_xdl_fp32.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_fp32.cpp
@@ -1,30 +1,7 @@
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_multi_d_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = F32;
 using BDataType        = F32;

--- a/example/24_batched_gemm/batched_gemm_xdl_int4.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_int4.cpp
@@ -1,28 +1,7 @@
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_multi_d_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = ck::int4_t;
 using BDataType        = ck::int4_t;

--- a/example/24_batched_gemm/batched_gemm_xdl_int8.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_int8.cpp
@@ -1,28 +1,7 @@
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_multi_d_xdl.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = int8_t;
 using BDataType        = int8_t;

--- a/example/24_batched_gemm/common.hpp
+++ b/example/24_batched_gemm/common.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <cstdlib>
+#include <initializer_list>
+#include <iostream>
+#include <numeric>
+#include <random>
+
+#include "ck/ck.hpp"
+#include "ck/tensor_operation/gpu/device/device_batched_gemm_multi_d_xdl.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+
+#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/literals.hpp"
+
+template <ck::index_t... Is>
+using S = ck::Sequence<Is...>;
+
+using BF16 = ck::bhalf_t;
+using F16  = ck::half_t;
+using F32  = float;
+
+using Row = ck::tensor_layout::gemm::RowMajor;
+using Col = ck::tensor_layout::gemm::ColumnMajor;
+
+using PassThrough = ck::tensor_operation::element_wise::PassThrough;

--- a/example/24_batched_gemm/run_batched_gemm_example.inc
+++ b/example/24_batched_gemm/run_batched_gemm_example.inc
@@ -1,4 +1,5 @@
-#include <random>
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 
@@ -28,8 +29,6 @@ struct ExecutionConfig final
 
 bool run_batched_gemm(const ProblemSize& problem_size, const ExecutionConfig& config)
 {
-    using namespace ck::literals;
-
 #if defined(BUILD_INT4_EXAMPLE) && defined(CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4)
     static_assert(sizeof(ck::int4_t) == sizeof(int8_t));
     static_assert(sizeof(ADataType) == sizeof(KernelADataType));
@@ -48,6 +47,8 @@ bool run_batched_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
            batch_stride_C,
            batch_count] = problem_size;
 
+    using namespace ck::literals;
+
     // GEMM shape
     auto f_host_tensor_descriptor = [](std::size_t batch_count_,
                                        std::size_t row,
@@ -55,15 +56,13 @@ bool run_batched_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
                                        std::size_t stride,
                                        std::size_t batch_stride,
                                        auto layout) {
-        if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
+        if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count_, row, col}),
-                                        std::vector<std::size_t>({batch_stride, stride, 1}));
+            return HostTensorDescriptor({batch_count_, row, col}, {batch_stride, stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count_, row, col}),
-                                        std::vector<std::size_t>({batch_stride, 1, stride}));
+            return HostTensorDescriptor({batch_count_, row, col}, {batch_stride, 1_uz, stride});
         }
     };
 
@@ -79,9 +78,9 @@ bool run_batched_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
         f_host_tensor_descriptor(batch_count, M, N, stride_C, batch_stride_C, ELayout{}));
 #endif
 
-    std::cout << "a_g_m_k: " << a_g_m_k.mDesc << std::endl;
-    std::cout << "b_g_k_n: " << b_g_k_n.mDesc << std::endl;
-    std::cout << "e_g_m_n: " << e_g_m_n_device_result.mDesc << std::endl;
+    std::cout << "a_g_m_k: " << a_g_m_k.GetDesc() << std::endl;
+    std::cout << "b_g_k_n: " << b_g_k_n.GetDesc() << std::endl;
+    std::cout << "e_g_m_n: " << e_g_m_n_device_result.GetDesc() << std::endl;
 
     switch(config.init_method)
     {
@@ -96,19 +95,19 @@ bool run_batched_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
         break;
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_g_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_g_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_device_buf(sizeof(EDataType) * e_g_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_g_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_g_k_n.GetMemorySize());
+    DeviceMem c_device_buf(e_g_m_n_device_result.GetMemorySize());
 
 #ifdef BUILD_INT4_EXAMPLE
     const Tensor<KernelADataType> a_g_m_k_converted(a_g_m_k);
     const Tensor<KernelBDataType> b_g_k_n_converted(b_g_k_n);
 
-    a_device_buf.ToDevice(a_g_m_k_converted.mData.data());
-    b_device_buf.ToDevice(b_g_k_n_converted.mData.data());
+    a_device_buf.ToDevice(a_g_m_k_converted.data());
+    b_device_buf.ToDevice(b_g_k_n_converted.data());
 #else
-    a_device_buf.ToDevice(a_g_m_k.mData.data());
-    b_device_buf.ToDevice(b_g_k_n.mData.data());
+    a_device_buf.ToDevice(a_g_m_k.data());
+    b_device_buf.ToDevice(b_g_k_n.data());
 #endif
     auto a_element_op   = AElementOp{};
     auto b_element_op   = BElementOp{};
@@ -150,7 +149,7 @@ bool run_batched_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
 
     if(config.do_verification)
     {
-        c_device_buf.FromDevice(e_g_m_n_device_result.mData.data());
+        c_device_buf.FromDevice(e_g_m_n_device_result.data());
 
         using ReferenceBatchedGemmInstance =
             ck::tensor_operation::host::ReferenceBatchedGemm<ADataType,
@@ -174,11 +173,11 @@ bool run_batched_gemm(const ProblemSize& problem_size, const ExecutionConfig& co
 
 #ifdef BUILD_INT4_EXAMPLE
         const Tensor<EDataType> e_device_result_converted(e_g_m_n_device_result);
-        pass &= ck::utils::check_err(e_device_result_converted.mData, e_g_m_n_host_result.mData);
+        pass &= ck::utils::check_err(e_device_result_converted, e_g_m_n_host_result);
 
 #else
         pass = ck::utils::check_err(
-            e_g_m_n_device_result.mData, e_g_m_n_host_result.mData, "Error: Incorrect results c");
+            e_g_m_n_device_result, e_g_m_n_host_result, "Error: Incorrect results c");
 #endif
     }
 

--- a/example/25_gemm_bias_e_permute/gemm_bias_e_permute_g1m2n3k1_xdl_fp16.cpp
+++ b/example/25_gemm_bias_e_permute/gemm_bias_e_permute_g1m2n3k1_xdl_fp16.cpp
@@ -1,22 +1,23 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_contraction_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/array.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -110,7 +111,7 @@ struct ReferenceContraction_G1_M2_N3_K1 : public ck::tensor_operation::device::B
         float Run(const Argument& arg)
         {
             auto f_gs_ms_ns = [&](auto g0, auto m0, auto m1, auto n0, auto n1, auto n2) {
-                const int K0 = arg.a_gs_ms_ks_.mDesc.GetLengths()[3];
+                const int K0 = arg.a_gs_ms_ks_.GetLengths()[3];
 
                 AccDataType v_acc = 0;
 
@@ -136,12 +137,12 @@ struct ReferenceContraction_G1_M2_N3_K1 : public ck::tensor_operation::device::B
             };
 
             make_ParallelTensorFunctor(f_gs_ms_ns,
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[0],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[1],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[2],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[3],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[4],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[5])(
+                                       arg.e_gs_ms_ns_.GetLengths()[0],
+                                       arg.e_gs_ms_ns_.GetLengths()[1],
+                                       arg.e_gs_ms_ns_.GetLengths()[2],
+                                       arg.e_gs_ms_ns_.GetLengths()[3],
+                                       arg.e_gs_ms_ns_.GetLengths()[4],
+                                       arg.e_gs_ms_ns_.GetLengths()[5])(
                 std::thread::hardware_concurrency());
 
             return 0;
@@ -246,26 +247,16 @@ int main(int argc, char* argv[])
         exit(0);
     }
 
-    Tensor<ADataType> a_gs_ms_ks(
-        std::vector<std::size_t>(a_gs_ms_ks_lengths.begin(), a_gs_ms_ks_lengths.end()),
-        std::vector<std::size_t>(a_gs_ms_ks_strides.begin(), a_gs_ms_ks_strides.end()));
-    Tensor<BDataType> b_gs_ns_ks(
-        std::vector<std::size_t>(b_gs_ns_ks_lengths.begin(), b_gs_ns_ks_lengths.end()),
-        std::vector<std::size_t>(b_gs_ns_ks_strides.begin(), b_gs_ns_ks_strides.end()));
-    Tensor<DDataType> d_gs_ms_ns(
-        std::vector<std::size_t>(d_gs_ms_ns_lengths.begin(), d_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(d_gs_ms_ns_strides.begin(), d_gs_ms_ns_strides.end()));
-    Tensor<EDataType> e_gs_ms_ns_host_result(
-        std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
-    Tensor<EDataType> e_gs_ms_ns_device_result(
-        std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
+    Tensor<ADataType> a_gs_ms_ks(a_gs_ms_ks_lengths, a_gs_ms_ks_strides);
+    Tensor<BDataType> b_gs_ns_ks(b_gs_ns_ks_lengths, b_gs_ns_ks_strides);
+    Tensor<DDataType> d_gs_ms_ns(d_gs_ms_ns_lengths, d_gs_ms_ns_strides);
+    Tensor<EDataType> e_gs_ms_ns_host_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
+    Tensor<EDataType> e_gs_ms_ns_device_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
 
-    std::cout << "a_gs_ms_ks: " << a_gs_ms_ks.mDesc << std::endl;
-    std::cout << "b_gs_ns_ks: " << b_gs_ns_ks.mDesc << std::endl;
-    std::cout << "d_gs_ms_ns: " << d_gs_ms_ns.mDesc << std::endl;
-    std::cout << "e_gs_ms_ns: " << e_gs_ms_ns_host_result.mDesc << std::endl;
+    std::cout << "a_gs_ms_ks: " << a_gs_ms_ks.GetDesc() << std::endl;
+    std::cout << "b_gs_ns_ks: " << b_gs_ns_ks.GetDesc() << std::endl;
+    std::cout << "d_gs_ms_ns: " << d_gs_ms_ns.GetDesc() << std::endl;
+    std::cout << "e_gs_ms_ns: " << e_gs_ms_ns_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -282,15 +273,14 @@ int main(int argc, char* argv[])
         break;
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_gs_ms_ks.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_gs_ns_ks.mDesc.GetElementSpaceSize());
-    DeviceMem d_device_buf(sizeof(DDataType) * d_gs_ms_ns.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) *
-                           e_gs_ms_ns_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_gs_ms_ks.GetMemorySize());
+    DeviceMem b_device_buf(b_gs_ns_ks.GetMemorySize());
+    DeviceMem d_device_buf(d_gs_ms_ns.GetMemorySize());
+    DeviceMem e_device_buf(e_gs_ms_ns_device_result.GetMemorySize());
 
-    a_device_buf.ToDevice(a_gs_ms_ks.mData.data());
-    b_device_buf.ToDevice(b_gs_ns_ks.mData.data());
-    d_device_buf.ToDevice(d_gs_ms_ns.mData.data());
+    a_device_buf.ToDevice(a_gs_ms_ks.data());
+    b_device_buf.ToDevice(b_gs_ns_ks.data());
+    d_device_buf.ToDevice(d_gs_ms_ns.data());
 
     // set zero
     e_device_buf.SetZero();
@@ -299,19 +289,21 @@ int main(int argc, char* argv[])
     auto b_element_op   = BElementOp{};
     auto cde_element_op = CDEElementOp{};
 
+    using ck::utils::to_array;
+
     // device operation
     auto op       = DeviceOpInstance{};
     auto invoker  = op.MakeInvoker();
     auto argument = op.MakeArgument(a_device_buf.GetDeviceBuffer(),
                                     b_device_buf.GetDeviceBuffer(),
-                                    std::array<const void*, 1>{d_device_buf.GetDeviceBuffer()},
+                                    to_array({d_device_buf.GetDeviceBuffer()}),
                                     e_device_buf.GetDeviceBuffer(),
                                     a_gs_ms_ks_lengths,
                                     a_gs_ms_ks_strides,
                                     b_gs_ns_ks_lengths,
                                     b_gs_ns_ks_strides,
-                                    std::array<std::vector<ck::index_t>, 1>{d_gs_ms_ns_lengths},
-                                    std::array<std::vector<ck::index_t>, 1>{d_gs_ms_ns_strides},
+                                    to_array({d_gs_ms_ns_lengths}),
+                                    to_array({d_gs_ms_ns_strides}),
                                     e_gs_ms_ns_lengths,
                                     e_gs_ms_ns_strides,
                                     a_element_op,
@@ -327,20 +319,20 @@ int main(int argc, char* argv[])
 
     float ave_time = invoker.Run(argument, StreamConfig{nullptr, time_kernel});
 
-    std::size_t M = std::accumulate(e_gs_ms_ns_lengths.begin() + NumDimG,
-                                    e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    std::size_t M = ck::accumulate_n(e_gs_ms_ns_lengths.begin() + NumDimG,
+                                     NumDimM,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
-    std::size_t N = std::accumulate(e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM,
-                                    e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM + NumDimN,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    std::size_t N = ck::accumulate_n(e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM,
+                                     NumDimN,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
-    std::size_t K = std::accumulate(a_gs_ms_ks_lengths.begin() + NumDimG + NumDimM,
-                                    a_gs_ms_ks_lengths.begin() + NumDimG + NumDimM + NumDimK,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    std::size_t K = ck::accumulate_n(a_gs_ms_ks_lengths.begin() + NumDimG + NumDimM,
+                                     NumDimK,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
     std::size_t flop      = std::size_t(2) * M * N * K;
     std::size_t num_btype = sizeof(ADataType) * M * K + sizeof(BDataType) * K * N +
@@ -353,13 +345,11 @@ int main(int argc, char* argv[])
     std::cout << "Perf: " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
               << op.GetTypeString() << std::endl;
 
-    e_device_buf.FromDevice(e_gs_ms_ns_device_result.mData.data());
+    e_device_buf.FromDevice(e_gs_ms_ns_device_result.data());
 
     if(do_verification)
     {
-        Tensor<CShuffleDataType> c_gs_ms_ns_host_result(
-            std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-            std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
+        Tensor<CShuffleDataType> c_gs_ms_ns_host_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
 
         using ReferenceOpInstance = ReferenceContraction_G1_M2_N3_K1<NumDimM,
                                                                      NumDimN,
@@ -384,18 +374,17 @@ int main(int argc, char* argv[])
 
         ref_invoker.Run(ref_argument);
 
-        for(size_t g0 = 0; g0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[0]; ++g0)
+        for(size_t g0 = 0; g0 < e_gs_ms_ns_host_result.GetLengths()[0]; ++g0)
         {
-            for(size_t m0 = 0; m0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[1]; ++m0)
+            for(size_t m0 = 0; m0 < e_gs_ms_ns_host_result.GetLengths()[1]; ++m0)
             {
-                for(size_t m1 = 0; m1 < e_gs_ms_ns_host_result.mDesc.GetLengths()[2]; ++m1)
+                for(size_t m1 = 0; m1 < e_gs_ms_ns_host_result.GetLengths()[2]; ++m1)
                 {
-                    for(size_t n0 = 0; n0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[3]; ++n0)
+                    for(size_t n0 = 0; n0 < e_gs_ms_ns_host_result.GetLengths()[3]; ++n0)
                     {
-                        for(size_t n1 = 0; n1 < e_gs_ms_ns_host_result.mDesc.GetLengths()[4]; ++n1)
+                        for(size_t n1 = 0; n1 < e_gs_ms_ns_host_result.GetLengths()[4]; ++n1)
                         {
-                            for(size_t n2 = 0; n2 < e_gs_ms_ns_host_result.mDesc.GetLengths()[5];
-                                ++n2)
+                            for(size_t n2 = 0; n2 < e_gs_ms_ns_host_result.GetLengths()[5]; ++n2)
                             {
                                 cde_element_op(e_gs_ms_ns_host_result(g0, m0, m1, n0, n1, n2),
                                                c_gs_ms_ns_host_result(g0, m0, m1, n0, n1, n2),
@@ -407,9 +396,7 @@ int main(int argc, char* argv[])
             }
         }
 
-        return ck::utils::check_err(e_gs_ms_ns_device_result.mData, e_gs_ms_ns_host_result.mData)
-                   ? 0
-                   : 1;
+        return ck::utils::check_err(e_gs_ms_ns_device_result, e_gs_ms_ns_host_result) ? 0 : 1;
     }
 
     return 0;

--- a/example/25_gemm_bias_e_permute/gemm_bias_e_permute_g1m3n2k1_xdl_fp16.cpp
+++ b/example/25_gemm_bias_e_permute/gemm_bias_e_permute_g1m3n2k1_xdl_fp16.cpp
@@ -1,20 +1,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_contraction_multiple_d_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/array.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -108,7 +110,7 @@ struct ReferenceContraction_G1_M3_N2_K1 : public ck::tensor_operation::device::B
         float Run(const Argument& arg)
         {
             auto f_gs_ms_ns = [&](auto g0, auto m0, auto m1, auto m2, auto n0, auto n1) {
-                const int K0 = arg.a_gs_ms_ks_.mDesc.GetLengths()[4];
+                const int K0 = arg.a_gs_ms_ks_.GetLengths()[4];
 
                 AccDataType v_acc = 0;
 
@@ -134,12 +136,12 @@ struct ReferenceContraction_G1_M3_N2_K1 : public ck::tensor_operation::device::B
             };
 
             make_ParallelTensorFunctor(f_gs_ms_ns,
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[0],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[1],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[2],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[3],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[4],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[5])(
+                                       arg.e_gs_ms_ns_.GetLengths()[0],
+                                       arg.e_gs_ms_ns_.GetLengths()[1],
+                                       arg.e_gs_ms_ns_.GetLengths()[2],
+                                       arg.e_gs_ms_ns_.GetLengths()[3],
+                                       arg.e_gs_ms_ns_.GetLengths()[4],
+                                       arg.e_gs_ms_ns_.GetLengths()[5])(
                 std::thread::hardware_concurrency());
 
             return 0;
@@ -246,26 +248,16 @@ int main(int argc, char* argv[])
         exit(0);
     }
 
-    Tensor<ADataType> a_gs_ms_ks(
-        std::vector<std::size_t>(a_gs_ms_ks_lengths.begin(), a_gs_ms_ks_lengths.end()),
-        std::vector<std::size_t>(a_gs_ms_ks_strides.begin(), a_gs_ms_ks_strides.end()));
-    Tensor<BDataType> b_gs_ns_ks(
-        std::vector<std::size_t>(b_gs_ns_ks_lengths.begin(), b_gs_ns_ks_lengths.end()),
-        std::vector<std::size_t>(b_gs_ns_ks_strides.begin(), b_gs_ns_ks_strides.end()));
-    Tensor<DDataType> d_gs_ms_ns(
-        std::vector<std::size_t>(d_gs_ms_ns_lengths.begin(), d_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(d_gs_ms_ns_strides.begin(), d_gs_ms_ns_strides.end()));
-    Tensor<EDataType> e_gs_ms_ns_host_result(
-        std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
-    Tensor<EDataType> e_gs_ms_ns_device_result(
-        std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
+    Tensor<ADataType> a_gs_ms_ks(a_gs_ms_ks_lengths, a_gs_ms_ks_strides);
+    Tensor<BDataType> b_gs_ns_ks(b_gs_ns_ks_lengths, b_gs_ns_ks_strides);
+    Tensor<DDataType> d_gs_ms_ns(d_gs_ms_ns_lengths, d_gs_ms_ns_strides);
+    Tensor<EDataType> e_gs_ms_ns_host_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
+    Tensor<EDataType> e_gs_ms_ns_device_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
 
-    std::cout << "a_gs_ms_ks: " << a_gs_ms_ks.mDesc << std::endl;
-    std::cout << "b_gs_ns_ks: " << b_gs_ns_ks.mDesc << std::endl;
-    std::cout << "d_gs_ms_ns: " << d_gs_ms_ns.mDesc << std::endl;
-    std::cout << "e_gs_ms_ns: " << e_gs_ms_ns_host_result.mDesc << std::endl;
+    std::cout << "a_gs_ms_ks: " << a_gs_ms_ks.GetDesc() << std::endl;
+    std::cout << "b_gs_ns_ks: " << b_gs_ns_ks.GetDesc() << std::endl;
+    std::cout << "d_gs_ms_ns: " << d_gs_ms_ns.GetDesc() << std::endl;
+    std::cout << "e_gs_ms_ns: " << e_gs_ms_ns_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -282,15 +274,14 @@ int main(int argc, char* argv[])
         break;
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_gs_ms_ks.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_gs_ns_ks.mDesc.GetElementSpaceSize());
-    DeviceMem d_device_buf(sizeof(DDataType) * d_gs_ms_ns.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) *
-                           e_gs_ms_ns_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_gs_ms_ks.GetMemorySize());
+    DeviceMem b_device_buf(b_gs_ns_ks.GetMemorySize());
+    DeviceMem d_device_buf(d_gs_ms_ns.GetMemorySize());
+    DeviceMem e_device_buf(e_gs_ms_ns_device_result.GetMemorySize());
 
-    a_device_buf.ToDevice(a_gs_ms_ks.mData.data());
-    b_device_buf.ToDevice(b_gs_ns_ks.mData.data());
-    d_device_buf.ToDevice(d_gs_ms_ns.mData.data());
+    a_device_buf.ToDevice(a_gs_ms_ks.data());
+    b_device_buf.ToDevice(b_gs_ns_ks.data());
+    d_device_buf.ToDevice(d_gs_ms_ns.data());
 
     // set zero
     e_device_buf.SetZero();
@@ -299,19 +290,21 @@ int main(int argc, char* argv[])
     auto b_element_op   = BElementOp{};
     auto cde_element_op = CDEElementOp{};
 
+    using ck::utils::to_array;
+
     // device operation
     auto op       = DeviceOpInstance{};
     auto invoker  = op.MakeInvoker();
     auto argument = op.MakeArgument(a_device_buf.GetDeviceBuffer(),
                                     b_device_buf.GetDeviceBuffer(),
-                                    std::array<const void*, 1>{d_device_buf.GetDeviceBuffer()},
+                                    to_array({d_device_buf.GetDeviceBuffer()}),
                                     e_device_buf.GetDeviceBuffer(),
                                     a_gs_ms_ks_lengths,
                                     a_gs_ms_ks_strides,
                                     b_gs_ns_ks_lengths,
                                     b_gs_ns_ks_strides,
-                                    std::array<std::vector<ck::index_t>, 1>{d_gs_ms_ns_lengths},
-                                    std::array<std::vector<ck::index_t>, 1>{d_gs_ms_ns_strides},
+                                    to_array({d_gs_ms_ns_lengths}),
+                                    to_array({d_gs_ms_ns_strides}),
                                     e_gs_ms_ns_lengths,
                                     e_gs_ms_ns_strides,
                                     a_element_op,
@@ -327,20 +320,18 @@ int main(int argc, char* argv[])
 
     float ave_time = invoker.Run(argument, StreamConfig{nullptr, time_kernel});
 
-    ck::index_t M = std::accumulate(e_gs_ms_ns_lengths.begin(),
-                                    e_gs_ms_ns_lengths.begin() + NumDimM,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t M = ck::accumulate_n(
+        e_gs_ms_ns_lengths.begin(), NumDimM, ck::index_t{1}, std::multiplies<ck::index_t>{});
 
-    ck::index_t N = std::accumulate(e_gs_ms_ns_lengths.begin() + NumDimM,
-                                    e_gs_ms_ns_lengths.begin() + NumDimM + NumDimN,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t N = ck::accumulate_n(e_gs_ms_ns_lengths.begin() + NumDimM,
+                                     NumDimN,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
-    ck::index_t K = std::accumulate(a_gs_ms_ks_lengths.begin() + NumDimM,
-                                    a_gs_ms_ks_lengths.begin() + NumDimM + NumDimK,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t K = ck::accumulate_n(a_gs_ms_ks_lengths.begin() + NumDimM,
+                                     NumDimK,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
     std::size_t flop      = std::size_t(2) * M * N * K;
     std::size_t num_btype = sizeof(ADataType) * M * K + sizeof(BDataType) * K * N +
@@ -353,13 +344,11 @@ int main(int argc, char* argv[])
     std::cout << "Perf: " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
               << op.GetTypeString() << std::endl;
 
-    e_device_buf.FromDevice(e_gs_ms_ns_device_result.mData.data());
+    e_device_buf.FromDevice(e_gs_ms_ns_device_result.data());
 
     if(do_verification)
     {
-        Tensor<CShuffleDataType> c_gs_ms_ns_host_result(
-            std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-            std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
+        Tensor<CShuffleDataType> c_gs_ms_ns_host_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
 
         using ReferenceOpInstance = ReferenceContraction_G1_M3_N2_K1<NumDimG,
                                                                      NumDimM,
@@ -385,18 +374,17 @@ int main(int argc, char* argv[])
 
         ref_invoker.Run(ref_argument);
 
-        for(size_t g0 = 0; g0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[0]; ++g0)
+        for(size_t g0 = 0; g0 < e_gs_ms_ns_host_result.GetLengths()[0]; ++g0)
         {
-            for(size_t m0 = 0; m0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[1]; ++m0)
+            for(size_t m0 = 0; m0 < e_gs_ms_ns_host_result.GetLengths()[1]; ++m0)
             {
-                for(size_t m1 = 0; m1 < e_gs_ms_ns_host_result.mDesc.GetLengths()[2]; ++m1)
+                for(size_t m1 = 0; m1 < e_gs_ms_ns_host_result.GetLengths()[2]; ++m1)
                 {
-                    for(size_t m2 = 0; m2 < e_gs_ms_ns_host_result.mDesc.GetLengths()[3]; ++m2)
+                    for(size_t m2 = 0; m2 < e_gs_ms_ns_host_result.GetLengths()[3]; ++m2)
                     {
-                        for(size_t n0 = 0; n0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[4]; ++n0)
+                        for(size_t n0 = 0; n0 < e_gs_ms_ns_host_result.GetLengths()[4]; ++n0)
                         {
-                            for(size_t n1 = 0; n1 < e_gs_ms_ns_host_result.mDesc.GetLengths()[5];
-                                ++n1)
+                            for(size_t n1 = 0; n1 < e_gs_ms_ns_host_result.GetLengths()[5]; ++n1)
                             {
                                 cde_element_op(e_gs_ms_ns_host_result(g0, m0, m1, m2, n0, n1),
                                                c_gs_ms_ns_host_result(g0, m0, m1, m2, n0, n1),
@@ -408,9 +396,7 @@ int main(int argc, char* argv[])
             }
         }
 
-        return ck::utils::check_err(e_gs_ms_ns_device_result.mData, e_gs_ms_ns_host_result.mData)
-                   ? 0
-                   : 1;
+        return ck::utils::check_err(e_gs_ms_ns_device_result, e_gs_ms_ns_host_result) ? 0 : 1;
     }
 
     return 0;

--- a/example/26_contraction/contraction_scale_xdl_fp32.cpp
+++ b/example/26_contraction/contraction_scale_xdl_fp32.cpp
@@ -1,20 +1,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/device_contraction_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/array.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -121,8 +123,8 @@ struct ReferenceContraction_M2_N2_K2 : public ck::tensor_operation::device::Base
         float Run(const Argument& arg)
         {
             auto f_ms_ns = [&](auto m0, auto m1, auto n0, auto n1) {
-                const int K0 = arg.a_ms_ks_.mDesc.GetLengths()[2];
-                const int K1 = arg.a_ms_ks_.mDesc.GetLengths()[3];
+                const int K0 = arg.a_ms_ks_.GetLengths()[2];
+                const int K1 = arg.a_ms_ks_.GetLengths()[3];
 
                 AccDataType v_acc = 0;
 
@@ -150,10 +152,10 @@ struct ReferenceContraction_M2_N2_K2 : public ck::tensor_operation::device::Base
             };
 
             make_ParallelTensorFunctor(f_ms_ns,
-                                       arg.e_ms_ns_.mDesc.GetLengths()[0],
-                                       arg.e_ms_ns_.mDesc.GetLengths()[1],
-                                       arg.e_ms_ns_.mDesc.GetLengths()[2],
-                                       arg.e_ms_ns_.mDesc.GetLengths()[3])(
+                                       arg.e_ms_ns_.GetLengths()[0],
+                                       arg.e_ms_ns_.GetLengths()[1],
+                                       arg.e_ms_ns_.GetLengths()[2],
+                                       arg.e_ms_ns_.GetLengths()[3])(
                 std::thread::hardware_concurrency());
 
             return 0;
@@ -277,22 +279,14 @@ int main(int argc, char* argv[])
         exit(0);
     }
 
-    Tensor<ADataType> a_ms_ks(
-        std::vector<std::size_t>(a_ms_ks_lengths.begin(), a_ms_ks_lengths.end()),
-        std::vector<std::size_t>(a_ms_ks_strides.begin(), a_ms_ks_strides.end()));
-    Tensor<BDataType> b_ns_ks(
-        std::vector<std::size_t>(b_ns_ks_lengths.begin(), b_ns_ks_lengths.end()),
-        std::vector<std::size_t>(b_ns_ks_strides.begin(), b_ns_ks_strides.end()));
-    Tensor<EDataType> e_ms_ns_host_result(
-        std::vector<std::size_t>(e_ms_ns_lengths.begin(), e_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_ms_ns_strides.begin(), e_ms_ns_strides.end()));
-    Tensor<EDataType> e_ms_ns_device_result(
-        std::vector<std::size_t>(e_ms_ns_lengths.begin(), e_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_ms_ns_strides.begin(), e_ms_ns_strides.end()));
+    Tensor<ADataType> a_ms_ks(a_ms_ks_lengths, a_ms_ks_strides);
+    Tensor<BDataType> b_ns_ks(b_ns_ks_lengths, b_ns_ks_strides);
+    Tensor<EDataType> e_ms_ns_host_result(e_ms_ns_lengths, e_ms_ns_strides);
+    Tensor<EDataType> e_ms_ns_device_result(e_ms_ns_lengths, e_ms_ns_strides);
 
-    std::cout << "a_ms_ks: " << a_ms_ks.mDesc << std::endl;
-    std::cout << "b_ns_ks: " << b_ns_ks.mDesc << std::endl;
-    std::cout << "e_ms_ns: " << e_ms_ns_host_result.mDesc << std::endl;
+    std::cout << "a_ms_ks: " << a_ms_ks.GetDesc() << std::endl;
+    std::cout << "b_ns_ks: " << b_ns_ks.GetDesc() << std::endl;
+    std::cout << "e_ms_ns: " << e_ms_ns_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -307,12 +301,12 @@ int main(int argc, char* argv[])
         break;
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_ms_ks.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_ns_ks.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) * e_ms_ns_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_ms_ks.GetMemorySize());
+    DeviceMem b_device_buf(b_ns_ks.GetMemorySize());
+    DeviceMem e_device_buf(e_ms_ns_device_result.GetMemorySize());
 
-    a_device_buf.ToDevice(a_ms_ks.mData.data());
-    b_device_buf.ToDevice(b_ns_ks.mData.data());
+    a_device_buf.ToDevice(a_ms_ks.data());
+    b_device_buf.ToDevice(b_ns_ks.data());
 
     // set zero
     e_device_buf.SetZero();
@@ -321,19 +315,21 @@ int main(int argc, char* argv[])
     auto b_element_op   = BElementOp{};
     auto cde_element_op = CDEElementOp{scale};
 
+    using ck::utils::empty_array;
+
     // device operation
     auto op       = DeviceOpInstance{};
     auto invoker  = op.MakeInvoker();
     auto argument = op.MakeArgument(a_device_buf.GetDeviceBuffer(),
                                     b_device_buf.GetDeviceBuffer(),
-                                    std::array<const void*, 0>{},
+                                    empty_array(),
                                     e_device_buf.GetDeviceBuffer(),
                                     a_ms_ks_lengths,
                                     a_ms_ks_strides,
                                     b_ns_ks_lengths,
                                     b_ns_ks_strides,
-                                    std::array<std::vector<ck::index_t>, 0>{},
-                                    std::array<std::vector<ck::index_t>, 0>{},
+                                    empty_array(),
+                                    empty_array(),
                                     e_ms_ns_lengths,
                                     e_ms_ns_strides,
                                     a_element_op,
@@ -349,20 +345,14 @@ int main(int argc, char* argv[])
 
     float ave_time = invoker.Run(argument, StreamConfig{nullptr, time_kernel});
 
-    ck::index_t M = std::accumulate(e_ms_ns_lengths.begin(),
-                                    e_ms_ns_lengths.begin() + NumDimM,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t M = ck::accumulate_n(
+        e_ms_ns_lengths.begin(), NumDimM, ck::index_t{1}, std::multiplies<ck::index_t>{});
 
-    ck::index_t N = std::accumulate(e_ms_ns_lengths.begin() + NumDimM,
-                                    e_ms_ns_lengths.begin() + NumDimM + NumDimN,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t N = ck::accumulate_n(
+        e_ms_ns_lengths.begin() + NumDimM, NumDimN, ck::index_t{1}, std::multiplies<ck::index_t>{});
 
-    ck::index_t K = std::accumulate(a_ms_ks_lengths.begin() + NumDimM,
-                                    a_ms_ks_lengths.begin() + NumDimM + NumDimK,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t K = ck::accumulate_n(
+        a_ms_ks_lengths.begin() + NumDimM, NumDimK, ck::index_t{1}, std::multiplies<ck::index_t>{});
 
     std::size_t flop = std::size_t(2) * M * N * K;
     std::size_t num_btype =
@@ -375,13 +365,11 @@ int main(int argc, char* argv[])
     std::cout << "Perf: " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
               << op.GetTypeString() << std::endl;
 
-    e_device_buf.FromDevice(e_ms_ns_device_result.mData.data());
+    e_device_buf.FromDevice(e_ms_ns_device_result.data());
 
     if(do_verification)
     {
-        Tensor<CShuffleDataType> c_ms_ns_host_result(
-            std::vector<std::size_t>(e_ms_ns_lengths.begin(), e_ms_ns_lengths.end()),
-            std::vector<std::size_t>(e_ms_ns_strides.begin(), e_ms_ns_strides.end()));
+        Tensor<CShuffleDataType> c_ms_ns_host_result(e_ms_ns_lengths, e_ms_ns_strides);
 
         using ReferenceOpInstance = ReferenceContraction_M2_N2_K2<NumDimM,
                                                                   NumDimN,
@@ -402,13 +390,13 @@ int main(int argc, char* argv[])
 
         ref_invoker.Run(ref_argument);
 
-        for(size_t m0 = 0; m0 < e_ms_ns_host_result.mDesc.GetLengths()[0]; ++m0)
+        for(size_t m0 = 0; m0 < e_ms_ns_host_result.GetLengths()[0]; ++m0)
         {
-            for(size_t m1 = 0; m1 < e_ms_ns_host_result.mDesc.GetLengths()[1]; ++m1)
+            for(size_t m1 = 0; m1 < e_ms_ns_host_result.GetLengths()[1]; ++m1)
             {
-                for(size_t n0 = 0; n0 < e_ms_ns_host_result.mDesc.GetLengths()[2]; ++n0)
+                for(size_t n0 = 0; n0 < e_ms_ns_host_result.GetLengths()[2]; ++n0)
                 {
-                    for(size_t n1 = 0; n1 < e_ms_ns_host_result.mDesc.GetLengths()[3]; ++n1)
+                    for(size_t n1 = 0; n1 < e_ms_ns_host_result.GetLengths()[3]; ++n1)
                     {
                         cde_element_op(e_ms_ns_host_result(m0, m1, n0, n1),
                                        c_ms_ns_host_result(m0, m1, n0, n1));
@@ -417,7 +405,7 @@ int main(int argc, char* argv[])
             }
         }
 
-        return ck::utils::check_err(e_ms_ns_device_result.mData, e_ms_ns_host_result.mData) ? 0 : 1;
+        return ck::utils::check_err(e_ms_ns_device_result, e_ms_ns_host_result) ? 0 : 1;
     }
 
     return 0;

--- a/example/29_batched_gemm_bias_e_permute/batched_gemm_bias_e_permute_xdl_fp16.cpp
+++ b/example/29_batched_gemm_bias_e_permute/batched_gemm_bias_e_permute_xdl_fp16.cpp
@@ -1,20 +1,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_contraction_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/array.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -109,7 +111,7 @@ struct ReferenceContraction_G2_M2_N2_K1 : public ck::tensor_operation::device::B
         float Run(const Argument& arg)
         {
             auto f_ms_ns = [&](auto g0, auto g1, auto m0, auto m1, auto n0, auto n1) {
-                const int K0 = arg.a_gs_ms_ks_.mDesc.GetLengths()[4];
+                const int K0 = arg.a_gs_ms_ks_.GetLengths()[4];
 
                 AccDataType v_acc = 0;
 
@@ -136,12 +138,12 @@ struct ReferenceContraction_G2_M2_N2_K1 : public ck::tensor_operation::device::B
             };
 
             make_ParallelTensorFunctor(f_ms_ns,
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[0],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[1],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[2],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[3],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[4],
-                                       arg.e_gs_ms_ns_.mDesc.GetLengths()[5])(
+                                       arg.e_gs_ms_ns_.GetLengths()[0],
+                                       arg.e_gs_ms_ns_.GetLengths()[1],
+                                       arg.e_gs_ms_ns_.GetLengths()[2],
+                                       arg.e_gs_ms_ns_.GetLengths()[3],
+                                       arg.e_gs_ms_ns_.GetLengths()[4],
+                                       arg.e_gs_ms_ns_.GetLengths()[5])(
                 std::thread::hardware_concurrency());
 
             return 0;
@@ -246,26 +248,16 @@ int main(int argc, char* argv[])
         exit(0);
     }
 
-    Tensor<ADataType> a_gs_ms_ks(
-        std::vector<std::size_t>(a_gs_ms_ks_lengths.begin(), a_gs_ms_ks_lengths.end()),
-        std::vector<std::size_t>(a_gs_ms_ks_strides.begin(), a_gs_ms_ks_strides.end()));
-    Tensor<BDataType> b_gs_ns_ks(
-        std::vector<std::size_t>(b_gs_ns_ks_lengths.begin(), b_gs_ns_ks_lengths.end()),
-        std::vector<std::size_t>(b_gs_ns_ks_strides.begin(), b_gs_ns_ks_strides.end()));
-    Tensor<DDataType> d_gs_ms_ns(
-        std::vector<std::size_t>(d_gs_ms_ns_lengths.begin(), d_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(d_gs_ms_ns_strides.begin(), d_gs_ms_ns_strides.end()));
-    Tensor<EDataType> e_gs_ms_ns_host_result(
-        std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
-    Tensor<EDataType> e_gs_ms_ns_device_result(
-        std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-        std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
+    Tensor<ADataType> a_gs_ms_ks(a_gs_ms_ks_lengths, a_gs_ms_ks_strides);
+    Tensor<BDataType> b_gs_ns_ks(b_gs_ns_ks_lengths, b_gs_ns_ks_strides);
+    Tensor<DDataType> d_gs_ms_ns(d_gs_ms_ns_lengths, d_gs_ms_ns_strides);
+    Tensor<EDataType> e_gs_ms_ns_host_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
+    Tensor<EDataType> e_gs_ms_ns_device_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
 
-    std::cout << "a_gs_ms_ks: " << a_gs_ms_ks.mDesc << std::endl;
-    std::cout << "b_gs_ns_ks: " << b_gs_ns_ks.mDesc << std::endl;
-    std::cout << "d_gs_ms_ns: " << d_gs_ms_ns.mDesc << std::endl;
-    std::cout << "e_gs_ms_ns: " << e_gs_ms_ns_host_result.mDesc << std::endl;
+    std::cout << "a_gs_ms_ks: " << a_gs_ms_ks.GetDesc() << std::endl;
+    std::cout << "b_gs_ns_ks: " << b_gs_ns_ks.GetDesc() << std::endl;
+    std::cout << "d_gs_ms_ns: " << d_gs_ms_ns.GetDesc() << std::endl;
+    std::cout << "e_gs_ms_ns: " << e_gs_ms_ns_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -282,15 +274,14 @@ int main(int argc, char* argv[])
         break;
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_gs_ms_ks.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_gs_ns_ks.mDesc.GetElementSpaceSize());
-    DeviceMem d_device_buf(sizeof(DDataType) * d_gs_ms_ns.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) *
-                           e_gs_ms_ns_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_gs_ms_ks.GetMemorySize());
+    DeviceMem b_device_buf(b_gs_ns_ks.GetMemorySize());
+    DeviceMem d_device_buf(d_gs_ms_ns.GetMemorySize());
+    DeviceMem e_device_buf(e_gs_ms_ns_device_result.GetMemorySize());
 
-    a_device_buf.ToDevice(a_gs_ms_ks.mData.data());
-    b_device_buf.ToDevice(b_gs_ns_ks.mData.data());
-    d_device_buf.ToDevice(d_gs_ms_ns.mData.data());
+    a_device_buf.ToDevice(a_gs_ms_ks.data());
+    b_device_buf.ToDevice(b_gs_ns_ks.data());
+    d_device_buf.ToDevice(d_gs_ms_ns.data());
 
     // set zero
     e_device_buf.SetZero();
@@ -299,19 +290,21 @@ int main(int argc, char* argv[])
     auto b_element_op   = BElementOp{};
     auto cde_element_op = CDEElementOp{};
 
+    using ck::utils::to_array;
+
     // device operation
     auto op       = DeviceOpInstance{};
     auto invoker  = op.MakeInvoker();
     auto argument = op.MakeArgument(a_device_buf.GetDeviceBuffer(),
                                     b_device_buf.GetDeviceBuffer(),
-                                    std::array<const void*, 1>{d_device_buf.GetDeviceBuffer()},
+                                    to_array({d_device_buf.GetDeviceBuffer()}),
                                     e_device_buf.GetDeviceBuffer(),
                                     a_gs_ms_ks_lengths,
                                     a_gs_ms_ks_strides,
                                     b_gs_ns_ks_lengths,
                                     b_gs_ns_ks_strides,
-                                    std::array<std::vector<ck::index_t>, 1>{d_gs_ms_ns_lengths},
-                                    std::array<std::vector<ck::index_t>, 1>{d_gs_ms_ns_strides},
+                                    to_array({d_gs_ms_ns_lengths}),
+                                    to_array({d_gs_ms_ns_strides}),
                                     e_gs_ms_ns_lengths,
                                     e_gs_ms_ns_strides,
                                     a_element_op,
@@ -327,25 +320,23 @@ int main(int argc, char* argv[])
 
     float ave_time = invoker.Run(argument, StreamConfig{nullptr, time_kernel});
 
-    ck::index_t G = std::accumulate(e_gs_ms_ns_lengths.begin(),
-                                    e_gs_ms_ns_lengths.begin() + NumDimG,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t G = ck::accumulate_n(
+        e_gs_ms_ns_lengths.begin(), NumDimG, ck::index_t{1}, std::multiplies<ck::index_t>{});
 
-    ck::index_t M = std::accumulate(e_gs_ms_ns_lengths.begin() + NumDimG,
-                                    e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t M = ck::accumulate_n(e_gs_ms_ns_lengths.begin() + NumDimG,
+                                     NumDimM,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
-    ck::index_t N = std::accumulate(e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM,
-                                    e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM + NumDimN,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t N = ck::accumulate_n(e_gs_ms_ns_lengths.begin() + NumDimG + NumDimM,
+                                     NumDimN,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
-    ck::index_t K = std::accumulate(a_gs_ms_ks_lengths.begin() + NumDimG + NumDimM,
-                                    a_gs_ms_ks_lengths.begin() + NumDimG + NumDimM + NumDimK,
-                                    ck::index_t{1},
-                                    std::multiplies<ck::index_t>{});
+    ck::index_t K = ck::accumulate_n(a_gs_ms_ks_lengths.begin() + NumDimG + NumDimM,
+                                     NumDimK,
+                                     ck::index_t{1},
+                                     std::multiplies<ck::index_t>{});
 
     std::size_t flop      = std::size_t(2) * G * M * N * K;
     std::size_t num_btype = sizeof(ADataType) * G * M * K + sizeof(BDataType) * G * K * N +
@@ -358,13 +349,11 @@ int main(int argc, char* argv[])
     std::cout << "Perf: " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
               << op.GetTypeString() << std::endl;
 
-    e_device_buf.FromDevice(e_gs_ms_ns_device_result.mData.data());
+    e_device_buf.FromDevice(e_gs_ms_ns_device_result.data());
 
     if(do_verification)
     {
-        Tensor<CShuffleDataType> c_ms_ns_host_result(
-            std::vector<std::size_t>(e_gs_ms_ns_lengths.begin(), e_gs_ms_ns_lengths.end()),
-            std::vector<std::size_t>(e_gs_ms_ns_strides.begin(), e_gs_ms_ns_strides.end()));
+        Tensor<CShuffleDataType> c_ms_ns_host_result(e_gs_ms_ns_lengths, e_gs_ms_ns_strides);
 
         using ReferenceOpInstance = ReferenceContraction_G2_M2_N2_K1<NumDimG,
                                                                      NumDimM,
@@ -386,18 +375,17 @@ int main(int argc, char* argv[])
 
         ref_invoker.Run(ref_argument);
 
-        for(size_t g0 = 0; g0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[0]; ++g0)
+        for(size_t g0 = 0; g0 < e_gs_ms_ns_host_result.GetLengths()[0]; ++g0)
         {
-            for(size_t g1 = 0; g1 < e_gs_ms_ns_host_result.mDesc.GetLengths()[1]; ++g1)
+            for(size_t g1 = 0; g1 < e_gs_ms_ns_host_result.GetLengths()[1]; ++g1)
             {
-                for(size_t m0 = 0; m0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[2]; ++m0)
+                for(size_t m0 = 0; m0 < e_gs_ms_ns_host_result.GetLengths()[2]; ++m0)
                 {
-                    for(size_t m1 = 0; m1 < e_gs_ms_ns_host_result.mDesc.GetLengths()[3]; ++m1)
+                    for(size_t m1 = 0; m1 < e_gs_ms_ns_host_result.GetLengths()[3]; ++m1)
                     {
-                        for(size_t n0 = 0; n0 < e_gs_ms_ns_host_result.mDesc.GetLengths()[4]; ++n0)
+                        for(size_t n0 = 0; n0 < e_gs_ms_ns_host_result.GetLengths()[4]; ++n0)
                         {
-                            for(size_t n1 = 0; n1 < e_gs_ms_ns_host_result.mDesc.GetLengths()[5];
-                                ++n1)
+                            for(size_t n1 = 0; n1 < e_gs_ms_ns_host_result.GetLengths()[5]; ++n1)
                             {
                                 cde_element_op(e_gs_ms_ns_host_result(g0, g1, m0, m1, n0, n1),
                                                c_ms_ns_host_result(g0, g1, m0, m1, n0, n1),
@@ -409,9 +397,7 @@ int main(int argc, char* argv[])
             }
         }
 
-        return ck::utils::check_err(e_gs_ms_ns_device_result.mData, e_gs_ms_ns_host_result.mData)
-                   ? 0
-                   : 1;
+        return ck::utils::check_err(e_gs_ms_ns_device_result, e_gs_ms_ns_host_result) ? 0 : 1;
     }
 
     return 0;

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_bf16.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_bf16.cpp
@@ -9,32 +9,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
                                                        Gemm1
 */
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using BF16 = ck::bhalf_t;
-using F32  = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = BF16;
 using B0DataType       = BF16;

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp16.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp16.cpp
@@ -9,32 +9,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
                                                        Gemm1
 */
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F16 = ck::half_t;
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = F16;
 using B0DataType       = F16;

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp32.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp32.cpp
@@ -9,31 +9,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
                                                        Gemm1
 */
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = F32;
 using B0DataType       = F32;

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int4.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int4.cpp
@@ -13,29 +13,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
 #error Should compile this file with ck::int4_t support
 #endif
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = ck::int4_t;
 using B0DataType       = ck::int4_t;

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int8.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int8.cpp
@@ -9,29 +9,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
                                                        Gemm1
 */
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType        = int8_t;
 using B0DataType       = int8_t;

--- a/example/31_batched_gemm_gemm/common.hpp
+++ b/example/31_batched_gemm_gemm/common.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <iostream>
+#include <numeric>
+#include <initializer_list>
+#include <cstdlib>
+
+#include "ck/ck.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
+#include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+
+#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/literals.hpp"
+
+template <ck::index_t... Is>
+using S = ck::Sequence<Is...>;
+
+using BF16 = ck::bhalf_t;
+using F16  = ck::half_t;
+using F32  = float;
+
+using Row = ck::tensor_layout::gemm::RowMajor;
+using Col = ck::tensor_layout::gemm::ColumnMajor;
+
+using PassThrough = ck::tensor_operation::element_wise::PassThrough;

--- a/example/31_batched_gemm_gemm/run_batched_gemm_gemm_example.inc
+++ b/example/31_batched_gemm_gemm/run_batched_gemm_gemm_example.inc
@@ -100,21 +100,21 @@ bool run_batched_gemm_gemm_example(int argc, char* argv[])
     BatchStrideB1 = BatchStrideB1 < 0 ? DefaultBatchStrideB1 : BatchStrideB1;
     BatchStrideC  = BatchStrideC < 0 ? DefaultBatchStrideC : BatchStrideC;
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor = [](std::size_t batch_count,
                                        std::size_t row,
                                        std::size_t col,
                                        std::size_t stride,
                                        std::size_t batch_stride,
                                        auto layout) {
-        if(std::is_same<decltype(layout), Row>::value)
+        if constexpr(std::is_same_v<decltype(layout), Row>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, stride, 1}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, 1, stride}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, 1_uz, stride});
         }
     };
 
@@ -130,10 +130,10 @@ bool run_batched_gemm_gemm_example(int argc, char* argv[])
     Tensor<CDataType> c_g_m_o_device_result(
         f_host_tensor_descriptor(BatchCount, M, O, StrideC, BatchStrideC, CLayout{}));
 
-    std::cout << "a_g_m_k: " << a_g_m_k.mDesc << std::endl;
-    std::cout << "b0_g_k_n: " << b0_g_k_n.mDesc << std::endl;
-    std::cout << "b1_g_n_o: " << b1_g_n_o.mDesc << std::endl;
-    std::cout << "c_g_m_o: " << c_g_m_o_host_result.mDesc << std::endl;
+    std::cout << "a_g_m_k: " << a_g_m_k.GetDesc() << std::endl;
+    std::cout << "b0_g_k_n: " << b0_g_k_n.GetDesc() << std::endl;
+    std::cout << "b1_g_n_o: " << b1_g_n_o.GetDesc() << std::endl;
+    std::cout << "c_g_m_o: " << c_g_m_o_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -155,29 +155,27 @@ bool run_batched_gemm_gemm_example(int argc, char* argv[])
     }
 
 #ifdef BUILD_INT4_EXAMPLE
-    DeviceMem a_g_m_k_device_buf(sizeof(KernelADataType) * a_g_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b0_g_k_n_device_buf(sizeof(KernelB0DataType) * b0_g_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem b1_g_n_o_device_buf(sizeof(KernelB1DataType) * b1_g_n_o.mDesc.GetElementSpaceSize());
-    DeviceMem c_g_m_o_device_buf(sizeof(KernelCDataType) *
-                                 c_g_m_o_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_g_m_k_device_buf(a_g_m_k.GetMemorySize());
+    DeviceMem b0_g_k_n_device_buf(b0_g_k_n.GetMemorySize());
+    DeviceMem b1_g_n_o_device_buf(b1_g_n_o.GetMemorySize());
+    DeviceMem c_g_m_o_device_buf(c_g_m_o_device_result.GetMemorySize());
 
     const Tensor<KernelADataType> a_g_m_k_converted(a_g_m_k);
     const Tensor<KernelB0DataType> b0_g_k_n_converted(b0_g_k_n);
     const Tensor<KernelB1DataType> b1_g_n_o_converted(b1_g_n_o);
 
-    a_g_m_k_device_buf.ToDevice(a_g_m_k_converted.mData.data());
-    b0_g_k_n_device_buf.ToDevice(b0_g_k_n_converted.mData.data());
-    b1_g_n_o_device_buf.ToDevice(b1_g_n_o_converted.mData.data());
+    a_g_m_k_device_buf.ToDevice(a_g_m_k_converted.data());
+    b0_g_k_n_device_buf.ToDevice(b0_g_k_n_converted.data());
+    b1_g_n_o_device_buf.ToDevice(b1_g_n_o_converted.data());
 #else
-    DeviceMem a_g_m_k_device_buf(sizeof(ADataType) * a_g_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b0_g_k_n_device_buf(sizeof(B0DataType) * b0_g_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem b1_g_n_o_device_buf(sizeof(B1DataType) * b1_g_n_o.mDesc.GetElementSpaceSize());
-    DeviceMem c_g_m_o_device_buf(sizeof(CDataType) *
-                                 c_g_m_o_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_g_m_k_device_buf(a_g_m_k.GetMemorySize());
+    DeviceMem b0_g_k_n_device_buf(b0_g_k_n.GetMemorySize());
+    DeviceMem b1_g_n_o_device_buf(b1_g_n_o.GetMemorySize());
+    DeviceMem c_g_m_o_device_buf(c_g_m_o_device_result.GetMemorySize());
 
-    a_g_m_k_device_buf.ToDevice(a_g_m_k.mData.data());
-    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.mData.data());
-    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.mData.data());
+    a_g_m_k_device_buf.ToDevice(a_g_m_k.data());
+    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.data());
+    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.data());
 #endif
 
     auto a_element_op    = AElementOp{};
@@ -189,36 +187,28 @@ bool run_batched_gemm_gemm_example(int argc, char* argv[])
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<KernelB0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<KernelB1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-        static_cast<KernelCDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-        static_cast<CDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-#endif
-        M,
-        N,
-        K,
-        O,
-        BatchCount,
-        StrideA,
-        StrideB0,
-        StrideB1,
-        StrideC,
-        BatchStrideA,
-        BatchStrideB0,
-        BatchStrideB1,
-        BatchStrideC,
-        a_element_op,
-        b0_element_op,
-        acc0_element_op,
-        b1_element_op,
-        c_element_op);
+    auto argument = gemm.MakeArgument(a_g_m_k_device_buf.GetDeviceBuffer(),
+                                      b0_g_k_n_device_buf.GetDeviceBuffer(),
+                                      b1_g_n_o_device_buf.GetDeviceBuffer(),
+                                      c_g_m_o_device_buf.GetDeviceBuffer(),
+                                      M,
+                                      N,
+                                      K,
+                                      O,
+                                      BatchCount,
+                                      StrideA,
+                                      StrideB0,
+                                      StrideB1,
+                                      StrideC,
+                                      BatchStrideA,
+                                      BatchStrideB0,
+                                      BatchStrideB1,
+                                      BatchStrideC,
+                                      a_element_op,
+                                      b0_element_op,
+                                      acc0_element_op,
+                                      b1_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {
@@ -261,16 +251,16 @@ bool run_batched_gemm_gemm_example(int argc, char* argv[])
         ref_gemm1_invoker.Run(ref_gemm1_argument);
 
 #ifdef BUILD_INT4_EXAMPLE
-        Tensor<KernelCDataType> c_g_m_o_device_result_converted(c_g_m_o_host_result.mDesc);
+        Tensor<KernelCDataType> c_g_m_o_device_result_converted(c_g_m_o_host_result.GetDesc());
 
-        c_g_m_o_device_buf.FromDevice(c_g_m_o_device_result_converted.mData.data());
+        c_g_m_o_device_buf.FromDevice(c_g_m_o_device_result_converted.data());
 
         c_g_m_o_device_result = c_g_m_o_device_result_converted.CopyAsType<CDataType>();
 #else
-        c_g_m_o_device_buf.FromDevice(c_g_m_o_device_result.mData.data());
+        c_g_m_o_device_buf.FromDevice(c_g_m_o_device_result.data());
 #endif
 
-        return ck::utils::check_err(c_g_m_o_device_result.mData, c_g_m_o_host_result.mData);
+        return ck::utils::check_err(c_g_m_o_device_result, c_g_m_o_host_result);
     }
 
     return true;

--- a/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_lower_triangle_scale_softmax_gemm_permute_xdl_fp16.cpp
+++ b/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_lower_triangle_scale_softmax_gemm_permute_xdl_fp16.cpp
@@ -9,23 +9,24 @@ Gemm + Softmax + Gemm fused operation. Computes C_g_m_o = Softmax(A_g_m_k * B0_g
                                                                           Gemm1
 */
 
+#include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <numeric>
-#include <initializer_list>
-#include <cstdlib>
 
 #include "ck/ck.hpp"
+#include "ck/tensor_operation/gpu/device/device_batched_gemm_softmax_gemm_permute_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_batched_gemm_softmax_gemm_permute_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
+#include "ck/library/reference_tensor_operation/cpu/reference_softmax.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_softmax.hpp"
+#include "ck/library/utility/literals.hpp"
 
 template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
@@ -222,7 +223,9 @@ int main(int argc, char* argv[])
     BatchStrideB0 = BatchStrideB0 < 0 ? DefaultBatchStrideB0 : BatchStrideB0;
     BatchStrideB1 = BatchStrideB1 < 0 ? DefaultBatchStrideB1 : BatchStrideB1;
 
-    const int BatchCount = G0 * G1;
+    const ck::index_t BatchCount = G0 * G1;
+
+    using namespace ck::literals;
 
     auto f_host_tensor_descriptor = [](std::size_t batch_count,
                                        std::size_t row,
@@ -230,15 +233,13 @@ int main(int argc, char* argv[])
                                        std::size_t stride,
                                        std::size_t batch_stride,
                                        auto layout) {
-        if(std::is_same<decltype(layout), Row>::value)
+        if constexpr(std::is_same_v<decltype(layout), Row>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, stride, 1}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, 1, stride}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, 1_uz, stride});
         }
     };
 
@@ -249,17 +250,13 @@ int main(int argc, char* argv[])
         f_host_tensor_descriptor(BatchCount, K, N, StrideB0, BatchStrideB0, B0Layout{}));
     Tensor<B1DataType> b1_g_n_o(
         f_host_tensor_descriptor(BatchCount, N, O, StrideB1, BatchStrideB1, B1Layout{}));
-    Tensor<CDataType> c_gs_ms_os_host_result(
-        std::vector<std::size_t>(c_gs_ms_os_lengths.begin(), c_gs_ms_os_lengths.end()),
-        std::vector<std::size_t>(c_gs_ms_os_strides.begin(), c_gs_ms_os_strides.end()));
-    Tensor<CDataType> c_gs_ms_os_device_result(
-        std::vector<std::size_t>(c_gs_ms_os_lengths.begin(), c_gs_ms_os_lengths.end()),
-        std::vector<std::size_t>(c_gs_ms_os_strides.begin(), c_gs_ms_os_strides.end()));
+    Tensor<CDataType> c_gs_ms_os_host_result(c_gs_ms_os_lengths, c_gs_ms_os_strides);
+    Tensor<CDataType> c_gs_ms_os_device_result(c_gs_ms_os_lengths, c_gs_ms_os_strides);
 
-    std::cout << "a_g_m_k: " << a_g_m_k.mDesc << std::endl;
-    std::cout << "b0_g_k_n: " << b0_g_k_n.mDesc << std::endl;
-    std::cout << "b1_g_n_o: " << b1_g_n_o.mDesc << std::endl;
-    std::cout << "c_gs_ms_os: " << c_gs_ms_os_host_result.mDesc << std::endl;
+    std::cout << "a_g_m_k: " << a_g_m_k.GetDesc() << std::endl;
+    std::cout << "b0_g_k_n: " << b0_g_k_n.GetDesc() << std::endl;
+    std::cout << "b1_g_n_o: " << b1_g_n_o.GetDesc() << std::endl;
+    std::cout << "c_gs_ms_os: " << c_gs_ms_os_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -285,15 +282,14 @@ int main(int argc, char* argv[])
         b1_g_n_o.GenerateTensorValue(GeneratorTensor_Diagonal<B1DataType>{});
     }
 
-    DeviceMem a_g_m_k_device_buf(sizeof(ADataType) * a_g_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b0_g_k_n_device_buf(sizeof(B0DataType) * b0_g_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem b1_g_n_o_device_buf(sizeof(B1DataType) * b1_g_n_o.mDesc.GetElementSpaceSize());
-    DeviceMem c_gs_ms_os_device_buf(sizeof(CDataType) *
-                                    c_gs_ms_os_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_g_m_k_device_buf(a_g_m_k.GetMemorySize());
+    DeviceMem b0_g_k_n_device_buf(b0_g_k_n.GetMemorySize());
+    DeviceMem b1_g_n_o_device_buf(b1_g_n_o.GetMemorySize());
+    DeviceMem c_gs_ms_os_device_buf(c_gs_ms_os_device_result.GetMemorySize());
 
-    a_g_m_k_device_buf.ToDevice(a_g_m_k.mData.data());
-    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.mData.data());
-    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.mData.data());
+    a_g_m_k_device_buf.ToDevice(a_g_m_k.data());
+    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.data());
+    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.data());
 
     auto a_element_op    = AElementOp{};
     auto b0_element_op   = B0ElementOp{};
@@ -302,31 +298,30 @@ int main(int argc, char* argv[])
     auto c_element_op    = CElementOp{};
 
     // do GEMM
-    auto gemm    = DeviceGemmInstance{};
-    auto invoker = gemm.MakeInvoker();
-    auto argument =
-        gemm.MakeArgument(static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-                          static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-                          static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-                          static_cast<CDataType*>(c_gs_ms_os_device_buf.GetDeviceBuffer()),
-                          M,
-                          N,
-                          K,
-                          O,
-                          BatchCount,
-                          c_gs_ms_os_lengths,
-                          c_gs_ms_os_strides,
-                          StrideA,
-                          StrideB0,
-                          StrideB1,
-                          BatchStrideA,
-                          BatchStrideB0,
-                          BatchStrideB1,
-                          a_element_op,
-                          b0_element_op,
-                          acc0_element_op,
-                          b1_element_op,
-                          c_element_op);
+    auto gemm     = DeviceGemmInstance{};
+    auto invoker  = gemm.MakeInvoker();
+    auto argument = gemm.MakeArgument(a_g_m_k_device_buf.GetDeviceBuffer(),
+                                      b0_g_k_n_device_buf.GetDeviceBuffer(),
+                                      b1_g_n_o_device_buf.GetDeviceBuffer(),
+                                      c_gs_ms_os_device_buf.GetDeviceBuffer(),
+                                      M,
+                                      N,
+                                      K,
+                                      O,
+                                      BatchCount,
+                                      c_gs_ms_os_lengths,
+                                      c_gs_ms_os_strides,
+                                      StrideA,
+                                      StrideB0,
+                                      StrideB1,
+                                      BatchStrideA,
+                                      BatchStrideB0,
+                                      BatchStrideB1,
+                                      a_element_op,
+                                      b0_element_op,
+                                      acc0_element_op,
+                                      b1_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {
@@ -351,15 +346,14 @@ int main(int argc, char* argv[])
 
     if(do_verification)
     {
-        c_gs_ms_os_device_buf.FromDevice(c_gs_ms_os_device_result.mData.data());
+        c_gs_ms_os_device_buf.FromDevice(c_gs_ms_os_device_result.data());
 
         // Output of Gemm0 is input A of Gemm1
         Tensor<AccDataType> acc0_g_m_n(f_host_tensor_descriptor(BatchCount, M, N, N, M * N, Row{}));
 
         Tensor<ADataType> a1_g_m_n(f_host_tensor_descriptor(BatchCount, M, N, N, M * N, Row{}));
 
-        Tensor<CDataType> c_g_m_o_host_result(std::vector<int>{BatchCount, M, O},
-                                              std::vector<int>{M * O, O, 1});
+        Tensor<CDataType> c_g_m_o_host_result({BatchCount, M, O}, {M * O, O, 1});
 
         auto ref_gemm0          = ReferenceGemm0Instance{};
         auto ref_gemm0_invoker  = ref_gemm0.MakeInvoker();
@@ -400,9 +394,7 @@ int main(int argc, char* argv[])
             self(idx) = c_g_m_o_host_result(g, idx[2], idx[3]);
         });
 
-        return ck::utils::check_err(c_gs_ms_os_device_result.mData, c_gs_ms_os_host_result.mData)
-                   ? 0
-                   : 1;
+        return ck::utils::check_err(c_gs_ms_os_device_result, c_gs_ms_os_host_result) ? 0 : 1;
     }
 
     return 0;

--- a/example/35_splitK_gemm/common.hpp
+++ b/example/35_splitK_gemm/common.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <cstdlib>
+#include <iostream>
+#include <numeric>
+#include <initializer_list>
+
+#include "ck/ck.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
+#include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/literals.hpp"
+
+template <ck::index_t... Is>
+using S = ck::Sequence<Is...>;
+
+using BF16 = ck::bhalf_t;
+using F16  = ck::half_t;
+using F32  = float;
+
+using Row = ck::tensor_layout::gemm::RowMajor;
+using Col = ck::tensor_layout::gemm::ColumnMajor;
+
+using PassThrough = ck::tensor_operation::element_wise::PassThrough;

--- a/example/35_splitK_gemm/run_splitK_gemm_example.inc
+++ b/example/35_splitK_gemm/run_splitK_gemm_example.inc
@@ -32,17 +32,17 @@ bool run_splitK_gemm(const ProblemSize& problem_size, const ExecutionConfig& con
 
     auto& [M, N, K, StrideA, StrideB, StrideC, KBatch] = problem_size;
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
             if(std::is_same<decltype(layout), ck::tensor_layout::gemm::RowMajor>::value)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -50,9 +50,9 @@ bool run_splitK_gemm(const ProblemSize& problem_size, const ExecutionConfig& con
     Tensor<BDataType> b_k_n(f_host_tensor_descriptor(K, N, StrideB, BLayout{}));
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "c_m_n: " << c_m_n_device_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "c_m_n: " << c_m_n_device_result.GetDesc() << std::endl;
 
     switch(config.init_method)
     {
@@ -70,19 +70,19 @@ bool run_splitK_gemm(const ProblemSize& problem_size, const ExecutionConfig& con
         b_k_n.GenerateTensorValue(GeneratorTensor_Sequential<1>{});
     }
 
-    DeviceMem a_m_k_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_k_n_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_m_n_device_buf(sizeof(CDataType) * c_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_m_k_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_k_n_device_buf(b_k_n.GetMemorySize());
+    DeviceMem c_m_n_device_buf(c_m_n_device_result.GetMemorySize());
 
 #ifdef BUILD_INT4_EXAMPLE
     const Tensor<KernelADataType> a_m_k_converted(a_m_k);
     const Tensor<KernelBDataType> b_k_n_converted(b_k_n);
 
-    a_m_k_device_buf.ToDevice(a_m_k_converted.mData.data());
-    b_k_n_device_buf.ToDevice(b_k_n_converted.mData.data());
+    a_m_k_device_buf.ToDevice(a_m_k_converted.data());
+    b_k_n_device_buf.ToDevice(b_k_n_converted.data());
 #else
-    a_m_k_device_buf.ToDevice(a_m_k.mData.data());
-    b_k_n_device_buf.ToDevice(b_k_n.mData.data());
+    a_m_k_device_buf.ToDevice(a_m_k.data());
+    b_k_n_device_buf.ToDevice(b_k_n.data());
 #endif
     c_m_n_device_buf.SetZero();
 
@@ -93,25 +93,19 @@ bool run_splitK_gemm(const ProblemSize& problem_size, const ExecutionConfig& con
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<KernelBDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-#endif
-        static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
-        M,
-        N,
-        K,
-        StrideA,
-        StrideB,
-        StrideC,
-        a_element_op,
-        b_element_op,
-        c_element_op,
-        KBatch);
+    auto argument = gemm.MakeArgument(a_m_k_device_buf.GetDeviceBuffer(),
+                                      b_k_n_device_buf.GetDeviceBuffer(),
+                                      c_m_n_device_buf.GetDeviceBuffer(),
+                                      M,
+                                      N,
+                                      K,
+                                      StrideA,
+                                      StrideB,
+                                      StrideC,
+                                      a_element_op,
+                                      b_element_op,
+                                      c_element_op,
+                                      KBatch);
 
     if(!gemm.IsSupportedArgument(argument))
     {
@@ -125,7 +119,7 @@ bool run_splitK_gemm(const ProblemSize& problem_size, const ExecutionConfig& con
 
     if(config.do_verification)
     {
-        c_m_n_device_buf.FromDevice(c_m_n_device_result.mData.data());
+        c_m_n_device_buf.FromDevice(c_m_n_device_result.data());
         using ReferenceGemmInstance = ck::tensor_operation::host::ReferenceGemm<ADataType,
                                                                                 BDataType,
                                                                                 CDataType,
@@ -146,15 +140,12 @@ bool run_splitK_gemm(const ProblemSize& problem_size, const ExecutionConfig& con
 
         if(std::is_same<CDataType, ck::half_t>::value)
         {
-            pass &= ck::utils::check_err(c_m_n_device_result.mData,
-                                         c_m_n_host_result.mData,
-                                         "fp16 incorrect result",
-                                         3e-3,
-                                         1e-3);
+            pass &= ck::utils::check_err(
+                c_m_n_device_result, c_m_n_host_result, "fp16 incorrect result", 3e-3, 1e-3);
         }
         else
         {
-            pass &= ck::utils::check_err(c_m_n_device_result.mData, c_m_n_host_result.mData);
+            pass &= ck::utils::check_err(c_m_n_device_result, c_m_n_host_result);
         }
     }
 

--- a/example/35_splitK_gemm/splitK_gemm_xdl_bfp16.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_bfp16.cpp
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using BF16 = ck::bhalf_t;
-using F32  = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType   = BF16;
 using BDataType   = BF16;

--- a/example/35_splitK_gemm/splitK_gemm_xdl_fp16.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_fp16.cpp
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F16 = ck::half_t;
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType   = F16;
 using BDataType   = F16;

--- a/example/35_splitK_gemm/splitK_gemm_xdl_fp32.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_fp32.cpp
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using F16 = ck::half_t;
-using F32 = float;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType   = F32;
 using BDataType   = F32;

--- a/example/35_splitK_gemm/splitK_gemm_xdl_int4.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_int4.cpp
@@ -1,30 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType   = ck::int4_t;
 using BDataType   = ck::int4_t;

--- a/example/35_splitK_gemm/splitK_gemm_xdl_int8.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_int8.cpp
@@ -1,30 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <iostream>
-#include <numeric>
-#include <initializer_list>
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "ck/library/utility/check_err.hpp"
-#include "ck/library/utility/device_memory.hpp"
-#include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
-#include "ck/library/utility/literals.hpp"
-
-template <ck::index_t... Is>
-using S = ck::Sequence<Is...>;
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+#include "common.hpp"
 
 using ADataType   = int8_t;
 using BDataType   = int8_t;

--- a/example/39_permute/run_permute_bundle_example.inc
+++ b/example/39_permute/run_permute_bundle_example.inc
@@ -16,13 +16,15 @@ bool run_permute_bundle(const Problem& problem)
     // initialize tensor by assigning DataType values
     ck::utils::FillUniformDistribution<DataType>{-1.f, 1.f}(input_bundle_tensor.AsSpan<DataType>());
 
-    DeviceMem input_device_buf(input_bundle_tensor.GetElementSpaceSizeInBytes());
-    DeviceMem output_device_buf(output_bundle_tensor.GetElementSpaceSizeInBytes());
+    DeviceMem input_device_buf(input_bundle_tensor.GetMemorySize());
+    DeviceMem output_device_buf(output_bundle_tensor.GetMemorySize());
 
     using std::data;
     input_device_buf.ToDevice(data(input_bundle_tensor));
 
     static_assert(std::is_default_constructible_v<DevicePermuteInstance>);
+
+    using ck::utils::to_array;
 
     auto permute  = DevicePermuteInstance{};
     auto argument = permute.MakeArgument(to_array(input_bundle_shape),
@@ -57,7 +59,7 @@ bool run_permute_bundle(const Problem& problem)
     using std::begin;
 
     Tensor<DataType> input_tensor(input_shape);
-    ranges::copy(input_bundle_tensor.AsSpan<const DataType>(), begin(input_tensor));
+    ck::ranges::copy(input_bundle_tensor.AsSpan<const DataType>(), begin(input_tensor));
 
     Tensor<DataType> output_tensor(transpose(input_shape, input_axes));
     if(!host_permute(input_tensor, input_axes, PassThrough{}, output_tensor))

--- a/example/39_permute/run_permute_element_example.inc
+++ b/example/39_permute/run_permute_element_example.inc
@@ -15,13 +15,15 @@ bool run_permute_element(const Problem& problem)
 
     ck::utils::FillUniformDistribution<InDataType>{-1.f, 1.f}(input_tensor);
 
-    DeviceMem input_device_buf(input_tensor.GetElementSpaceSizeInBytes());
-    DeviceMem output_device_buf(output_tensor.GetElementSpaceSizeInBytes());
+    DeviceMem input_device_buf(input_tensor.GetMemorySize());
+    DeviceMem output_device_buf(output_tensor.GetMemorySize());
 
     using std::data;
     input_device_buf.ToDevice(data(input_tensor));
 
     static_assert(std::is_default_constructible_v<DevicePermuteInstance>);
+
+    using ck::utils::to_array;
 
     auto permute  = DevicePermuteInstance{};
     auto argument = permute.MakeArgument(to_array(input_shape),

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_bf16.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_bf16.cpp
@@ -7,17 +7,19 @@
 #include <type_traits>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/algorithm.hpp"
 #include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
+#include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/utility/convolution_parameter.hpp"
-#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 using In0DataType       = ck::bhalf_t;
 using Wei0DataType      = ck::bhalf_t;

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp16.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp16.cpp
@@ -7,17 +7,19 @@
 #include <type_traits>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/algorithm.hpp"
 #include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
+#include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/utility/convolution_parameter.hpp"
-#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 using In0DataType       = ck::half_t;
 using Wei0DataType      = ck::half_t;

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp32.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp32.cpp
@@ -7,17 +7,19 @@
 #include <type_traits>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/algorithm.hpp"
 #include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
+#include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/utility/convolution_parameter.hpp"
-#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 using In0DataType       = float;
 using Wei0DataType      = float;

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int4.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int4.cpp
@@ -11,17 +11,19 @@
 #include <type_traits>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/algorithm.hpp"
 #include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
+#include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/utility/convolution_parameter.hpp"
-#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 using In0DataType        = ck::int4_t;
 using Wei0DataType       = ck::int4_t;

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int8.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int8.cpp
@@ -7,17 +7,19 @@
 #include <type_traits>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/algorithm.hpp"
 #include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
+#include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/utility/convolution_parameter.hpp"
-#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
+#include "ck/library/utility/numeric.hpp"
 
 using In0DataType       = int8_t;
 using Wei0DataType      = int8_t;

--- a/example/41_grouped_conv_conv_fwd/run_grouped_conv_conv_fwd_example.inc
+++ b/example/41_grouped_conv_conv_fwd/run_grouped_conv_conv_fwd_example.inc
@@ -37,10 +37,10 @@ bool run_grouped_conv_conv_fwd(bool do_verification,
     Tensor<Out1DataType> out1_host(out1_g_n_k_wos_desc);
     Tensor<Out1DataType> out1_device(out1_g_n_k_wos_desc);
 
-    std::cout << "in0: " << in0.mDesc << std::endl;
-    std::cout << "wei0: " << wei0.mDesc << std::endl;
-    std::cout << "wei1: " << wei1.mDesc << std::endl;
-    std::cout << "out1: " << out1_host.mDesc << std::endl;
+    std::cout << "in0: " << in0.GetDesc() << std::endl;
+    std::cout << "wei0: " << wei0.GetDesc() << std::endl;
+    std::cout << "wei1: " << wei1.GetDesc() << std::endl;
+    std::cout << "out1: " << out1_host.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -57,27 +57,27 @@ bool run_grouped_conv_conv_fwd(bool do_verification,
     }
 
 #ifdef BUILD_INT4_EXAMPLE
-    DeviceMem in0_device_buf(sizeof(KernelIn0DataType) * in0.mDesc.GetElementSpaceSize());
-    DeviceMem wei0_device_buf(sizeof(KernelWei0DataType) * wei0.mDesc.GetElementSpaceSize());
-    DeviceMem wei1_device_buf(sizeof(KernelWei1DataType) * wei1.mDesc.GetElementSpaceSize());
-    DeviceMem out1_device_buf(sizeof(KernelOut1DataType) * out1_device.mDesc.GetElementSpaceSize());
+    DeviceMem in0_device_buf(in0.GetMemorySize());
+    DeviceMem wei0_device_buf(wei0.GetMemorySize());
+    DeviceMem wei1_device_buf(wei1.GetMemorySize());
+    DeviceMem out1_device_buf(out1_device.GetMemorySize());
 
     const Tensor<KernelIn0DataType> in0_converted(in0);
     const Tensor<KernelWei0DataType> wei0_converted(wei0);
     const Tensor<KernelWei1DataType> wei1_converted(wei1);
 
-    in0_device_buf.ToDevice(in0_converted.mData.data());
-    wei0_device_buf.ToDevice(wei0_converted.mData.data());
-    wei1_device_buf.ToDevice(wei1_converted.mData.data());
+    in0_device_buf.ToDevice(in0_converted.data());
+    wei0_device_buf.ToDevice(wei0_converted.data());
+    wei1_device_buf.ToDevice(wei1_converted.data());
 #else
-    DeviceMem in0_device_buf(sizeof(In0DataType) * in0.mDesc.GetElementSpaceSize());
-    DeviceMem wei0_device_buf(sizeof(Wei0DataType) * wei0.mDesc.GetElementSpaceSize());
-    DeviceMem wei1_device_buf(sizeof(Wei1DataType) * wei1.mDesc.GetElementSpaceSize());
-    DeviceMem out1_device_buf(sizeof(Out1DataType) * out1_device.mDesc.GetElementSpaceSize());
+    DeviceMem in0_device_buf(in0.GetMemorySize());
+    DeviceMem wei0_device_buf(wei0.GetMemorySize());
+    DeviceMem wei1_device_buf(wei1.GetMemorySize());
+    DeviceMem out1_device_buf(out1_device.GetMemorySize());
 
-    in0_device_buf.ToDevice(in0.mData.data());
-    wei0_device_buf.ToDevice(wei0.mData.data());
-    wei1_device_buf.ToDevice(wei1.mData.data());
+    in0_device_buf.ToDevice(in0.data());
+    wei0_device_buf.ToDevice(wei0.data());
+    wei1_device_buf.ToDevice(wei1.data());
 #endif
 
     std::array<ck::index_t, NDimSpatial + 3> a0_g_n_c_wis_lengths{};
@@ -97,7 +97,7 @@ bool run_grouped_conv_conv_fwd(bool do_verification,
     std::array<ck::index_t, NDimSpatial> input1_left_pads{};
     std::array<ck::index_t, NDimSpatial> input1_right_pads{};
 
-    auto copy = [](auto& x, auto& y) { std::copy(x.begin(), x.end(), y.begin()); };
+    auto copy = [](const auto& x, auto& y) { ck::ranges::copy(x, y.begin()); };
 
     copy(in0_g_n_c_wis_desc.GetLengths(), a0_g_n_c_wis_lengths);
     copy(in0_g_n_c_wis_desc.GetStrides(), a0_g_n_c_wis_strides);
@@ -120,18 +120,17 @@ bool run_grouped_conv_conv_fwd(bool do_verification,
     const ck::index_t gemm_batch = a0_g_n_c_wis_lengths[0];
 
     const ck::index_t gemm0_m_length =
-        e1_g_n_k_wos_lengths[1] * std::accumulate(e1_g_n_k_wos_lengths.begin() + 3,
-                                                  e1_g_n_k_wos_lengths.begin() + 3 + NDimSpatial,
-                                                  ck::index_t{1},
-                                                  std::multiplies<ck::index_t>{});
+        e1_g_n_k_wos_lengths[1] * ck::accumulate_n(e1_g_n_k_wos_lengths.begin() + 3,
+                                                   NDimSpatial,
+                                                   ck::index_t{1},
+                                                   std::multiplies<ck::index_t>{});
 
     const ck::index_t gemm0_n_length = b0_g_k_c_xs_lengths[1];
 
-    const ck::index_t gemm0_k_length =
-        std::accumulate(b0_g_k_c_xs_lengths.begin() + 2,
-                        b0_g_k_c_xs_lengths.begin() + 2 + NDimSpatial + 1,
-                        ck::index_t{1},
-                        std::multiplies<ck::index_t>{});
+    const ck::index_t gemm0_k_length = ck::accumulate_n(b0_g_k_c_xs_lengths.begin() + 2,
+                                                        NDimSpatial + 1,
+                                                        ck::index_t{1},
+                                                        std::multiplies<ck::index_t>{});
 
     const ck::index_t gemm1_n_length = b1_g_k_c_xs_lengths[1];
 
@@ -149,36 +148,28 @@ bool run_grouped_conv_conv_fwd(bool do_verification,
 
     auto device_op = DeviceOpInstance{};
     auto invoker   = device_op.MakeInvoker();
-    auto argument  = device_op.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelIn0DataType*>(in0_device_buf.GetDeviceBuffer()),
-        static_cast<KernelWei0DataType*>(wei0_device_buf.GetDeviceBuffer()),
-        static_cast<KernelWei1DataType*>(wei1_device_buf.GetDeviceBuffer()),
-        static_cast<KernelOut1DataType*>(out1_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<In0DataType*>(in0_device_buf.GetDeviceBuffer()),
-        static_cast<Wei0DataType*>(wei0_device_buf.GetDeviceBuffer()),
-        static_cast<Wei1DataType*>(wei1_device_buf.GetDeviceBuffer()),
-        static_cast<Out1DataType*>(out1_device_buf.GetDeviceBuffer()),
-#endif
-        gemm0_m_length,
-        gemm0_n_length,
-        gemm0_k_length,
-        gemm1_n_length,
-        gemm_batch,
-        a0_stride,
-        b0_stride,
-        b1_stride,
-        e1_stride,
-        a0_batch_stride,
-        b0_batch_stride,
-        b1_batch_stride,
-        e1_batch_stride,
-        in0_element_op,
-        wei0_element_op,
-        out0_element_op,
-        wei1_element_op,
-        out1_element_op);
+    auto argument  = device_op.MakeArgument(in0_device_buf.GetDeviceBuffer(),
+                                           wei0_device_buf.GetDeviceBuffer(),
+                                           wei1_device_buf.GetDeviceBuffer(),
+                                           out1_device_buf.GetDeviceBuffer(),
+                                           gemm0_m_length,
+                                           gemm0_n_length,
+                                           gemm0_k_length,
+                                           gemm1_n_length,
+                                           gemm_batch,
+                                           a0_stride,
+                                           b0_stride,
+                                           b1_stride,
+                                           e1_stride,
+                                           a0_batch_stride,
+                                           b0_batch_stride,
+                                           b1_batch_stride,
+                                           e1_batch_stride,
+                                           in0_element_op,
+                                           wei0_element_op,
+                                           out0_element_op,
+                                           wei1_element_op,
+                                           out1_element_op);
 
     if(!device_op.IsSupportedArgument(argument))
     {
@@ -251,17 +242,17 @@ bool run_grouped_conv_conv_fwd(bool do_verification,
         ref_conv1_invoker.Run(ref_conv1_argument);
 
 #ifdef BUILD_INT4_EXAMPLE
-        Tensor<KernelOut1DataType> out1_device_converted(out1_host.mDesc);
+        Tensor<KernelOut1DataType> out1_device_converted(out1_host.GetDesc());
 
-        out1_device_buf.FromDevice(out1_device_converted.mData.data());
+        out1_device_buf.FromDevice(out1_device_converted.data());
 
         out1_device = out1_device_converted.CopyAsType<Out1DataType>();
 #else
-        out1_device_buf.FromDevice(out1_device.mData.data());
+        out1_device_buf.FromDevice(out1_device.data());
 #endif
 
         return ck::utils::check_err(
-            out1_device.mData, out1_host.mData, "Error: incorrect results!", 1e-5f, 1e-4f);
+            out1_device, out1_host, "Error: incorrect results!", 1e-5f, 1e-4f);
     }
 
     return true;

--- a/include/ck/utility/span.hpp
+++ b/include/ck/utility/span.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <array>
+#include <iterator>
 #include <type_traits>
 
 namespace ck {
@@ -13,16 +14,18 @@ template <typename T>
 class span
 {
     public:
-    using element_type    = T;
-    using value_type      = std::remove_cv_t<element_type>;
-    using size_type       = std::size_t;
-    using difference_type = std::ptrdiff_t;
-    using pointer         = element_type*;
-    using const_pointer   = const element_type*;
-    using reference       = element_type&;
-    using const_reference = const element_type&;
-    using iterator        = pointer;
-    using const_iterator  = pointer;
+    using element_type           = T;
+    using value_type             = std::remove_cv_t<element_type>;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+    using pointer                = element_type*;
+    using const_pointer          = const element_type*;
+    using reference              = element_type&;
+    using const_reference        = const element_type&;
+    using iterator               = pointer;
+    using const_iterator         = pointer;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     constexpr span() : span(nullptr, size_type{0}) {}
 
@@ -51,6 +54,12 @@ class span
     constexpr iterator end() const noexcept { return begin() + size(); }
     constexpr const_iterator cend() const noexcept { return end(); }
 
+    constexpr reverse_iterator rbegin() const noexcept { return std::make_reverse_iterator(end()); }
+    constexpr const_reverse_iterator crbegin() const noexcept { return rbegin(); }
+
+    constexpr reverse_iterator rend() const noexcept { return std::make_reverse_iterator(begin()); }
+    constexpr const_reverse_iterator crend() const noexcept { return rend(); }
+
     constexpr reference front() const { return *begin(); }
     constexpr reference back() const { return *(--end()); }
 
@@ -58,6 +67,29 @@ class span
     constexpr pointer data() const noexcept { return ptr_; }
 
     constexpr size_type size() const noexcept { return size_; }
+
+    constexpr bool empty() const noexcept { return size() == 0; }
+
+    friend constexpr iterator begin(const span& s) noexcept { return s.begin(); }
+    friend constexpr const_iterator cbegin(const span& s) noexcept { return s.begin(); }
+
+    friend constexpr iterator end(const span& s) noexcept { return s.end(); }
+    friend constexpr const_iterator cend(const span& s) noexcept { return s.end(); }
+
+    friend constexpr reverse_iterator rbegin(const span& s) noexcept { return s.rbegin(); }
+    friend constexpr const_reverse_iterator crbegin(const span& s) noexcept { return s.crbegin(); }
+
+    friend constexpr reverse_iterator rend(const span& s) noexcept { return s.rend(); }
+    friend constexpr const_reverse_iterator crend(const span& s) noexcept { return s.crend(); }
+
+    friend constexpr reference front(const span& s) { return s.front(); }
+    friend constexpr reference back(const span& s) { return s.back(); }
+
+    friend constexpr pointer data(const span& s) noexcept { return s.data(); }
+
+    friend constexpr size_type size(const span& s) noexcept { return s.size(); }
+
+    friend constexpr bool empty(const span& s) noexcept { return s.empty(); }
 
     private:
     pointer ptr_;

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp
@@ -57,7 +57,7 @@ struct ReferenceBatchedGemm : public device::BaseOperator
         float Run(const Argument& arg)
         {
             auto f_gmk_gkn_gmn = [&](auto g, auto m, auto n) {
-                const int K = arg.a_g_m_k_.mDesc.GetLengths()[2];
+                const int K = arg.a_g_m_k_.GetLengths()[2];
 
                 AccDataType v_acc = 0;
 
@@ -81,9 +81,9 @@ struct ReferenceBatchedGemm : public device::BaseOperator
             };
 
             make_ParallelTensorFunctor(f_gmk_gkn_gmn,
-                                       arg.c_g_m_n_.mDesc.GetLengths()[0],
-                                       arg.c_g_m_n_.mDesc.GetLengths()[1],
-                                       arg.c_g_m_n_.mDesc.GetLengths()[2])(
+                                       arg.c_g_m_n_.GetLengths()[0],
+                                       arg.c_g_m_n_.GetLengths()[1],
+                                       arg.c_g_m_n_.GetLengths()[2])(
                 std::thread::hardware_concurrency());
             return 0;
         }

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_batchnorm_forward_nhwc_c.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_batchnorm_forward_nhwc_c.hpp
@@ -3,13 +3,15 @@
 
 #pragma once
 
-#include <iostream>
-#include <vector>
-#include <array>
 #include <algorithm>
+#include <array>
+#include <iostream>
 #include <thread>
+#include <vector>
 
+#include "ck/library/utility/host_tensor.hpp"
 #include "ck/tensor_operation/gpu/device/device_batchnorm_forward.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_batchnorm_infer_nhwc_c.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_batchnorm_infer_nhwc_c.hpp
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <iostream>
 #include <vector>
-#include <array>
-#include <algorithm>
 
+#include "ck/library/utility/host_tensor.hpp"
 #include "ck/tensor_operation/gpu/device/device_batchnorm_infer.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_cgemm.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_cgemm.hpp
@@ -72,9 +72,9 @@ struct ReferenceCGemm : public device::BaseOperator
 
         float Run(const Argument& arg)
         {
-            const std::size_t K = arg.a_m_k_real_.mDesc.GetLengths()[1];
+            const std::size_t K = arg.a_m_k_real_.GetLengths()[1];
 
-            if(K != arg.a_m_k_imag_.mDesc.GetLengths()[1])
+            if(K != arg.a_m_k_imag_.GetLengths()[1])
             {
                 throw std::runtime_error("wrong! Incompatible real and imag sizes in CGEMM");
             }
@@ -111,13 +111,11 @@ struct ReferenceCGemm : public device::BaseOperator
                 arg.c_m_n_imag_(m, n) = ck::type_convert<CDataType>(v_c_imag);
             };
 
-            make_ParallelTensorFunctor(f_mk_kn_mn_real,
-                                       arg.c_m_n_real_.mDesc.GetLengths()[0],
-                                       arg.c_m_n_real_.mDesc.GetLengths()[1])(
+            make_ParallelTensorFunctor(
+                f_mk_kn_mn_real, arg.c_m_n_real_.GetLengths()[0], arg.c_m_n_real_.GetLengths()[1])(
                 std::thread::hardware_concurrency());
-            make_ParallelTensorFunctor(f_mk_kn_mn_imag,
-                                       arg.c_m_n_imag_.mDesc.GetLengths()[0],
-                                       arg.c_m_n_imag_.mDesc.GetLengths()[1])(
+            make_ParallelTensorFunctor(
+                f_mk_kn_mn_imag, arg.c_m_n_imag_.GetLengths()[0], arg.c_m_n_imag_.GetLengths()[1])(
                 std::thread::hardware_concurrency());
 
             return 0;

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation.hpp
@@ -76,14 +76,14 @@ struct ReferenceConvFwd_Bias_Activation : public device::BaseOperator
             auto f_nchw = [&](auto n, auto k, auto ho, auto wo) {
                 float v_acc = 0;
 
-                for(std::size_t c = 0; c < arg.wei_k_c_y_x_.mDesc.GetLengths()[1]; ++c)
+                for(std::size_t c = 0; c < arg.wei_k_c_y_x_.GetLengths()[1]; ++c)
                 {
-                    for(std::size_t y = 0; y < arg.wei_k_c_y_x_.mDesc.GetLengths()[2]; ++y)
+                    for(std::size_t y = 0; y < arg.wei_k_c_y_x_.GetLengths()[2]; ++y)
                     {
                         auto hi = ck::type_convert<ck::long_index_t>(ho * arg.conv_strides_[0]) +
                                   ck::type_convert<ck::long_index_t>(y * arg.conv_dilations_[0]) -
                                   ck::type_convert<ck::long_index_t>(arg.in_left_pads_[0]);
-                        for(std::size_t x = 0; x < arg.wei_k_c_y_x_.mDesc.GetLengths()[3]; ++x)
+                        for(std::size_t x = 0; x < arg.wei_k_c_y_x_.GetLengths()[3]; ++x)
                         {
                             auto wi =
                                 ck::type_convert<ck::long_index_t>(wo * arg.conv_strides_[1]) +
@@ -91,10 +91,10 @@ struct ReferenceConvFwd_Bias_Activation : public device::BaseOperator
                                 ck::type_convert<ck::long_index_t>(arg.in_left_pads_[1]);
                             if(hi >= 0 &&
                                ck::type_convert<std::size_t>(hi) <
-                                   arg.in_n_c_hi_wi_.mDesc.GetLengths()[2] &&
+                                   arg.in_n_c_hi_wi_.GetLengths()[2] &&
                                wi >= 0 &&
                                ck::type_convert<std::size_t>(wi) <
-                                   arg.in_n_c_hi_wi_.mDesc.GetLengths()[3])
+                                   arg.in_n_c_hi_wi_.GetLengths()[3])
                             {
                                 float v_in;
                                 float v_wei;
@@ -119,10 +119,10 @@ struct ReferenceConvFwd_Bias_Activation : public device::BaseOperator
             };
 
             make_ParallelTensorFunctor(f_nchw,
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[0],
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[1],
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[2],
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[3])(
+                                       arg.out_n_k_ho_wo_.GetLengths()[0],
+                                       arg.out_n_k_ho_wo_.GetLengths()[1],
+                                       arg.out_n_k_ho_wo_.GetLengths()[2],
+                                       arg.out_n_k_ho_wo_.GetLengths()[3])(
                 std::thread::hardware_concurrency());
             return 0;
         }

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation_add.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation_add.hpp
@@ -79,14 +79,14 @@ struct ReferenceConvFwd_Bias_Activation_Add : public device::BaseOperator
             auto f_nchw = [&](auto n, auto k, auto ho, auto wo) {
                 float v_acc = 0;
 
-                for(std::size_t c = 0; c < arg.wei_k_c_y_x_.mDesc.GetLengths()[1]; ++c)
+                for(std::size_t c = 0; c < arg.wei_k_c_y_x_.GetLengths()[1]; ++c)
                 {
-                    for(std::size_t y = 0; y < arg.wei_k_c_y_x_.mDesc.GetLengths()[2]; ++y)
+                    for(std::size_t y = 0; y < arg.wei_k_c_y_x_.GetLengths()[2]; ++y)
                     {
                         auto hi = ck::type_convert<ck::long_index_t>(ho * arg.conv_strides_[0]) +
                                   ck::type_convert<ck::long_index_t>(y * arg.conv_dilations_[0]) -
                                   ck::type_convert<ck::long_index_t>(arg.in_left_pads_[0]);
-                        for(std::size_t x = 0; x < arg.wei_k_c_y_x_.mDesc.GetLengths()[3]; ++x)
+                        for(std::size_t x = 0; x < arg.wei_k_c_y_x_.GetLengths()[3]; ++x)
                         {
                             auto wi =
                                 ck::type_convert<ck::long_index_t>(wo * arg.conv_strides_[1]) +
@@ -94,10 +94,10 @@ struct ReferenceConvFwd_Bias_Activation_Add : public device::BaseOperator
                                 ck::type_convert<ck::long_index_t>(arg.in_left_pads_[1]);
                             if(hi >= 0 &&
                                ck::type_convert<std::size_t>(hi) <
-                                   arg.in_n_c_hi_wi_.mDesc.GetLengths()[2] &&
+                                   arg.in_n_c_hi_wi_.GetLengths()[2] &&
                                wi >= 0 &&
                                ck::type_convert<std::size_t>(wi) <
-                                   arg.in_n_c_hi_wi_.mDesc.GetLengths()[3])
+                                   arg.in_n_c_hi_wi_.GetLengths()[3])
                             {
                                 float v_in;
                                 float v_wei;
@@ -125,10 +125,10 @@ struct ReferenceConvFwd_Bias_Activation_Add : public device::BaseOperator
             };
 
             make_ParallelTensorFunctor(f_nchw,
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[0],
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[1],
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[2],
-                                       arg.out_n_k_ho_wo_.mDesc.GetLengths()[3])(
+                                       arg.out_n_k_ho_wo_.GetLengths()[0],
+                                       arg.out_n_k_ho_wo_.GetLengths()[1],
+                                       arg.out_n_k_ho_wo_.GetLengths()[2],
+                                       arg.out_n_k_ho_wo_.GetLengths()[3])(
                 std::thread::hardware_concurrency());
             return 0;
         }

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm.hpp
@@ -57,7 +57,7 @@ struct ReferenceGemm : public device::BaseOperator
         float Run(const Argument& arg)
         {
             auto f_mk_kn_mn = [&](auto m, auto n) {
-                const int K = arg.a_m_k_.mDesc.GetLengths()[1];
+                const int K = arg.a_m_k_.GetLengths()[1];
 
                 AccDataType v_acc = 0;
 
@@ -81,7 +81,7 @@ struct ReferenceGemm : public device::BaseOperator
             };
 
             make_ParallelTensorFunctor(
-                f_mk_kn_mn, arg.c_m_n_.mDesc.GetLengths()[0], arg.c_m_n_.mDesc.GetLengths()[1])(
+                f_mk_kn_mn, arg.c_m_n_.GetLengths()[0], arg.c_m_n_.GetLengths()[1])(
                 std::thread::hardware_concurrency());
 
             return 0;

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_bias_2d.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_bias_2d.hpp
@@ -61,7 +61,7 @@ struct ReferenceGemmBias2D : public device::BaseOperator
         float Run(const Argument& arg)
         {
             auto f_mk_kn_mn = [&](auto m, auto n) {
-                const int K = arg.a_m_k_.mDesc.GetLengths()[1];
+                const int K = arg.a_m_k_.GetLengths()[1];
 
                 AccDataType a   = 0;
                 AccDataType b   = 0;
@@ -79,7 +79,7 @@ struct ReferenceGemmBias2D : public device::BaseOperator
             };
 
             make_ParallelTensorFunctor(
-                f_mk_kn_mn, arg.c_m_n_.mDesc.GetLengths()[0], arg.c_m_n_.mDesc.GetLengths()[1])(
+                f_mk_kn_mn, arg.c_m_n_.GetLengths()[0], arg.c_m_n_.GetLengths()[1])(
                 std::thread::hardware_concurrency());
 
             return 0;

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_bias_activation.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_bias_activation.hpp
@@ -60,7 +60,7 @@ struct ReferenceGemmBiasActivation : public device::BaseOperator
         float Run(const Argument& arg)
         {
             auto f_mk_kn_mn = [&](auto m, auto n) {
-                const int K = arg.a_m_k_.mDesc.GetLengths()[1];
+                const int K = arg.a_m_k_.GetLengths()[1];
 
                 float v_acc = 0;
 
@@ -83,7 +83,7 @@ struct ReferenceGemmBiasActivation : public device::BaseOperator
             };
 
             make_ParallelTensorFunctor(
-                f_mk_kn_mn, arg.c_m_n_.mDesc.GetLengths()[0], arg.c_m_n_.mDesc.GetLengths()[1])(
+                f_mk_kn_mn, arg.c_m_n_.GetLengths()[0], arg.c_m_n_.GetLengths()[1])(
                 std::thread::hardware_concurrency());
 
             return 0;

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_bias_activation_add.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_bias_activation_add.hpp
@@ -63,7 +63,7 @@ struct ReferenceGemmBiasActivationAdd : public device::BaseOperator
         float Run(const Argument& arg)
         {
             auto f_mk_kn_mn = [&](auto m, auto n) {
-                const int K = arg.a_m_k_.mDesc.GetLengths()[1];
+                const int K = arg.a_m_k_.GetLengths()[1];
 
                 float v_acc = 0;
 
@@ -89,7 +89,7 @@ struct ReferenceGemmBiasActivationAdd : public device::BaseOperator
             };
 
             make_ParallelTensorFunctor(
-                f_mk_kn_mn, arg.c_m_n_.mDesc.GetLengths()[0], arg.c_m_n_.mDesc.GetLengths()[1])(
+                f_mk_kn_mn, arg.c_m_n_.GetLengths()[0], arg.c_m_n_.GetLengths()[1])(
                 std::thread::hardware_concurrency());
 
             return 0;

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_layernorm.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_layernorm.hpp
@@ -46,8 +46,8 @@ struct ReferenceGemmLayernorm : public device::BaseOperator
         size_t M = acc.GetLengths()[0];
         size_t N = acc.GetLengths()[1];
 
-        Tensor<ComputeDataType> avg_acc_sq(HostTensorDescriptor(std::vector<size_t>({M})));
-        Tensor<ComputeDataType> avg_acc(HostTensorDescriptor(std::vector<size_t>({M})));
+        Tensor<ComputeDataType> avg_acc_sq({M});
+        Tensor<ComputeDataType> avg_acc({M});
         Tensor<ComputeDataType> acc_layernorm(acc);
 
         // reduce N dim

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_layernorm.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm_layernorm.hpp
@@ -5,7 +5,9 @@
 
 #include <iostream>
 #include <sstream>
+
 #include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
 
 namespace ck {
 namespace tensor_operation {
@@ -38,11 +40,11 @@ struct ReferenceGemmLayernorm : public device::BaseOperator
                              const Tensor<InDataType>& beta,     // 1xN
                              const InDataType epsilon = 1e-5)
     {
-        assert(acc.mDesc.GetLengths()[1] == gamma.mDesc.GetLengths()[0] &&
-               acc.mDesc.GetLengths()[1] == beta.mDesc.GetLengths()[0]);
+        assert(acc.GetLengths()[1] == gamma.GetLengths()[0] &&
+               acc.GetLengths()[1] == beta.GetLengths()[0]);
 
-        size_t M = acc.mDesc.GetLengths()[0];
-        size_t N = acc.mDesc.GetLengths()[1];
+        size_t M = acc.GetLengths()[0];
+        size_t N = acc.GetLengths()[1];
 
         Tensor<ComputeDataType> avg_acc_sq(HostTensorDescriptor(std::vector<size_t>({M})));
         Tensor<ComputeDataType> avg_acc(HostTensorDescriptor(std::vector<size_t>({M})));
@@ -131,7 +133,7 @@ struct ReferenceGemmLayernorm : public device::BaseOperator
 
         float Run(const Argument& arg)
         {
-            Tensor<AccDataType> acc_m_n(arg.c_m_n_.mDesc);
+            Tensor<AccDataType> acc_m_n(arg.c_m_n_.GetDesc());
             acc_m_n.GenerateTensorValue(GeneratorTensor_1<AccDataType>{0});
 
             auto ref_gemm     = ReferenceGemmInstance{};

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_softmax.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_softmax.hpp
@@ -30,7 +30,7 @@ struct ReferenceSoftmax : public device::BaseOperator
             : in_(in), out_(out), alpha_(alpha), beta_(beta), sm_reduce_dims_(sm_reduce_dims)
         {
             // std::cout << "debug: scalar dims: ";
-            for(size_t i = 0; i < in.mDesc.GetNumOfDimension(); i++)
+            for(size_t i = 0; i < in.GetNumOfDimension(); i++)
             {
                 if(std::find(sm_reduce_dims.begin(), sm_reduce_dims.end(), i) ==
                    sm_reduce_dims.end())
@@ -58,7 +58,7 @@ struct ReferenceSoftmax : public device::BaseOperator
             std::vector<size_t> scalar_lengths;
             for(index_t dim : arg.sm_scalar_dims_)
             {
-                scalar_lengths.push_back(arg.in_.mDesc.GetLengths()[dim]);
+                scalar_lengths.push_back(arg.in_.GetLengths()[dim]);
             }
 
             Tensor<AccDataType> reduce_max(scalar_lengths);
@@ -84,7 +84,7 @@ struct ReferenceSoftmax : public device::BaseOperator
             // LogRangeAsType<float>(std::cout << "reduce_max: ", reduce_max.mData, ",") <<
             // std::endl;
 
-            Tensor<AccDataType> in_stable(arg.in_.mDesc);
+            Tensor<AccDataType> in_stable(arg.in_.GetDesc());
             in_stable.ForEach([&](auto& self, auto idx) {
                 // numerator = exp(x - max(x))
                 self(idx) = std::exp(static_cast<AccDataType>(arg.in_(idx)) -

--- a/library/include/ck/library/utility/algorithm.hpp
+++ b/library/include/ck/library/utility/algorithm.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace ck {
+namespace ranges {
+template <typename InputRange, typename OutputIterator>
+auto copy(InputRange&& range, OutputIterator iter)
+    -> decltype(std::copy(std::begin(std::forward<InputRange>(range)),
+                          std::end(std::forward<InputRange>(range)),
+                          iter))
+{
+    return std::copy(std::begin(std::forward<InputRange>(range)),
+                     std::end(std::forward<InputRange>(range)),
+                     iter);
+}
+
+template <typename T, typename OutputRange>
+auto fill(OutputRange&& range, const T& init)
+    -> std::void_t<decltype(std::fill(std::begin(std::forward<OutputRange>(range)),
+                                      std::end(std::forward<OutputRange>(range)),
+                                      init))>
+{
+    std::fill(std::begin(std::forward<OutputRange>(range)),
+              std::end(std::forward<OutputRange>(range)),
+              init);
+}
+
+template <typename InputRange, typename OutputIterator, typename UnaryOperation>
+auto transform(InputRange&& range, OutputIterator iter, UnaryOperation unary_op)
+    -> decltype(std::transform(std::begin(range), std::end(range), iter, unary_op))
+{
+    return std::transform(std::begin(range), std::end(range), iter, unary_op);
+}
+
+} // namespace ranges
+} // namespace ck

--- a/library/include/ck/library/utility/array.hpp
+++ b/library/include/ck/library/utility/array.hpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <type_traits>
+
+#include "ck/library/utility/ranges.hpp"
+
+namespace ck {
+namespace utils {
+
+namespace detail {
+
+template <typename Range, std::size_t Size>
+class to_array_result;
+
+template <typename FromT, std::size_t Size>
+class to_array_result<FromT (&)[Size], Size> final
+{
+    public:
+    explicit constexpr to_array_result(FromT (&source)[Size]) noexcept : source_(source) {}
+
+    template <typename T>
+    operator std::array<T, Size>() const
+    {
+        static_assert(std::is_convertible_v<FromT, T>);
+
+        return copy_as_array<T>(source_, std::make_index_sequence<Size>{});
+    }
+
+    private:
+    template <typename T, std::size_t... Indices>
+    static std::array<T, Size> copy_as_array(FromT (&array)[Size], std::index_sequence<Indices...>)
+    {
+        return std::array<T, Size>{array[Indices]...};
+    }
+
+    private:
+    FromT (&source_)[Size];
+};
+
+template <typename FromT, std::size_t Size>
+class to_array_result<FromT(&&)[Size], Size> final
+{
+    public:
+    explicit constexpr to_array_result(FromT(&&source)[Size]) noexcept : source_(std::move(source))
+    {
+    }
+
+    template <typename T>
+    operator std::array<T, Size>() &&
+    {
+        static_assert(std::is_convertible_v<FromT, T>);
+
+        return move_as_array<T>(std::move(source_), std::make_index_sequence<Size>{});
+    }
+
+    private:
+    template <typename T, std::size_t... Indices>
+    static std::array<T, Size> move_as_array(FromT(&&array)[Size], std::index_sequence<Indices...>)
+    {
+        return std::array<T, Size>{std::move(array[Indices])...};
+    }
+
+    private:
+    FromT(&&source_)[Size];
+};
+
+template <typename Range>
+class to_array_result<Range, std::numeric_limits<std::size_t>::max()> final
+{
+    public:
+    explicit constexpr to_array_result(const Range& source) noexcept : source_(source) {}
+
+    template <typename T, std::size_t Size>
+    operator std::array<T, Size>() const
+    {
+        static_assert(std::is_convertible_v<ranges::range_value_t<Range>, T>);
+
+        std::array<T, Size> destination;
+
+        std::copy_n(std::begin(source_),
+                    std::min<std::size_t>(Size, std::size(source_)),
+                    std::begin(destination));
+
+        return destination;
+    }
+
+    private:
+    const Range& source_;
+};
+
+struct empty_array_result final
+{
+    template <typename T>
+    operator std::array<T, 0>() const
+    {
+        return std::array<T, 0>{};
+    }
+};
+} // namespace detail
+
+template <typename T, std::size_t N>
+inline constexpr auto to_array(T (&array)[N]) -> detail::to_array_result<decltype(array), N>
+{
+    return detail::to_array_result<decltype(array), N>{array};
+}
+
+template <typename T, std::size_t N>
+inline constexpr auto to_array(T(&&array)[N]) -> detail::to_array_result<decltype(array), N>
+{
+    return detail::to_array_result<decltype(array), N>{std::move(array)};
+}
+
+template <typename Range>
+inline constexpr auto to_array(const Range& range) noexcept
+    -> detail::to_array_result<ck::remove_cvref_t<Range>, std::numeric_limits<std::size_t>::max()>
+{
+    return detail::to_array_result<ck::remove_cvref_t<Range>,
+                                   std::numeric_limits<std::size_t>::max()>{range};
+}
+
+inline constexpr auto empty_array() noexcept { return detail::empty_array_result{}; }
+
+} // namespace utils
+} // namespace ck

--- a/library/include/ck/library/utility/buffer.hpp
+++ b/library/include/ck/library/utility/buffer.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+
+namespace ck {
+namespace utils {
+struct mutable_buffer
+{
+    using pointer   = std::byte*;
+    using size_type = std::size_t;
+
+    friend mutable_buffer operator+(const mutable_buffer& buffer, size_type n) noexcept
+    {
+        mutable_buffer advanced(buffer);
+        advanced += n;
+        return advanced;
+    }
+
+    constexpr mutable_buffer() noexcept : mutable_buffer(nullptr, 0) {}
+
+    constexpr mutable_buffer(void* data, size_type size = 0) noexcept
+        : data_(static_cast<pointer>(data)), size_(size)
+    {
+    }
+
+    constexpr mutable_buffer& operator+=(size_type n) noexcept
+    {
+        const size_type advance = std::min(size(), n);
+
+        data_ = data() + advance;
+        size_ = size() - advance;
+
+        return *this;
+    }
+
+    constexpr pointer data() const noexcept { return data_; }
+
+    constexpr size_type size() const noexcept { return size_; }
+
+    constexpr operator void*() const noexcept { return data(); }
+
+    constexpr operator const void*() const noexcept { return data(); }
+
+    // this method only exists while T is complete type
+    template <typename T, typename = std::void_t<decltype(sizeof(T))>>
+    constexpr operator T*() const noexcept
+    {
+        if(size() % sizeof(T) != 0)
+        {
+            return nullptr;
+        }
+
+        return reinterpret_cast<T*>(data());
+    }
+
+    private:
+    pointer data_;
+    size_type size_;
+};
+} // namespace utils
+} // namespace ck

--- a/library/include/ck/library/utility/check_err.hpp
+++ b/library/include/ck/library/utility/check_err.hpp
@@ -6,27 +6,32 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <iterator>
 #include <limits>
 #include <type_traits>
 #include <vector>
 
 #include "ck/ck.hpp"
+#include "ck/host_utility/io.hpp"
 #include "ck/utility/data_type.hpp"
 #include "ck/utility/span.hpp"
 #include "ck/utility/type.hpp"
-#include "ck/host_utility/io.hpp"
+
+#include "ck/library/utility/ranges.hpp"
 
 namespace ck {
 namespace utils {
 
-template <typename T>
-typename std::enable_if<std::is_floating_point<T>::value && !std::is_same<T, half_t>::value,
-                        bool>::type
-check_err(const std::vector<T>& out,
-          const std::vector<T>& ref,
+template <typename Range, typename RefRange>
+typename std::enable_if<
+    std::is_same_v<ranges::range_value_t<Range>, ranges::range_value_t<RefRange>> &&
+        std::is_floating_point_v<ranges::range_value_t<Range>> &&
+        !std::is_same_v<ranges::range_value_t<Range>, half_t>,
+    bool>::type
+check_err(const Range& out,
+          const RefRange& ref,
           const std::string& msg = "Error: Incorrect results!",
           double rtol            = 1e-5,
           double atol            = 3e-6)
@@ -44,15 +49,17 @@ check_err(const std::vector<T>& out,
     double max_err = std::numeric_limits<double>::min();
     for(std::size_t i = 0; i < ref.size(); ++i)
     {
-        err = std::abs(out[i] - ref[i]);
-        if(err > atol + rtol * std::abs(ref[i]) || !std::isfinite(out[i]) || !std::isfinite(ref[i]))
+        const double o = *std::next(std::begin(out), i);
+        const double r = *std::next(std::begin(ref), i);
+        err            = std::abs(o - r);
+        if(err > atol + rtol * std::abs(r) || !std::isfinite(o) || !std::isfinite(r))
         {
             max_err = err > max_err ? err : max_err;
             err_count++;
             if(err_count < 5)
             {
                 std::cerr << msg << std::setw(12) << std::setprecision(7) << " out[" << i
-                          << "] != ref[" << i << "]: " << out[i] << " != " << ref[i] << std::endl;
+                          << "] != ref[" << i << "]: " << o << " != " << r << std::endl;
             }
             res = false;
         }
@@ -64,10 +71,13 @@ check_err(const std::vector<T>& out,
     return res;
 }
 
-template <typename T>
-typename std::enable_if<std::is_same<T, bhalf_t>::value, bool>::type
-check_err(const std::vector<T>& out,
-          const std::vector<T>& ref,
+template <typename Range, typename RefRange>
+typename std::enable_if<
+    std::is_same_v<ranges::range_value_t<Range>, ranges::range_value_t<RefRange>> &&
+        std::is_same_v<ranges::range_value_t<Range>, bhalf_t>,
+    bool>::type
+check_err(const Range& out,
+          const RefRange& ref,
           const std::string& msg = "Error: Incorrect results!",
           double rtol            = 1e-3,
           double atol            = 1e-3)
@@ -86,9 +96,9 @@ check_err(const std::vector<T>& out,
     double max_err = std::numeric_limits<float>::min();
     for(std::size_t i = 0; i < ref.size(); ++i)
     {
-        double o = type_convert<float>(out[i]);
-        double r = type_convert<float>(ref[i]);
-        err      = std::abs(o - r);
+        const double o = type_convert<float>(*std::next(std::begin(out), i));
+        const double r = type_convert<float>(*std::next(std::begin(ref), i));
+        err            = std::abs(o - r);
         if(err > atol + rtol * std::abs(r) || !std::isfinite(o) || !std::isfinite(r))
         {
             max_err = err > max_err ? err : max_err;
@@ -108,10 +118,13 @@ check_err(const std::vector<T>& out,
     return res;
 }
 
-template <typename T>
-typename std::enable_if<std::is_same_v<T, half_t>, bool>::type
-check_err(span<const T> out,
-          span<const T> ref,
+template <typename Range, typename RefRange>
+typename std::enable_if<
+    std::is_same_v<ranges::range_value_t<Range>, ranges::range_value_t<RefRange>> &&
+        std::is_same_v<ranges::range_value_t<Range>, half_t>,
+    bool>::type
+check_err(const Range& out,
+          const RefRange& ref,
           const std::string& msg = "Error: Incorrect results!",
           double rtol            = 1e-3,
           double atol            = 1e-3)
@@ -126,12 +139,12 @@ check_err(span<const T> out,
     bool res{true};
     int err_count  = 0;
     double err     = 0;
-    double max_err = std::numeric_limits<T>::min();
+    double max_err = std::numeric_limits<ranges::range_value_t<Range>>::min();
     for(std::size_t i = 0; i < ref.size(); ++i)
     {
-        double o = type_convert<float>(out[i]);
-        double r = type_convert<float>(ref[i]);
-        err      = std::abs(o - r);
+        const double o = type_convert<float>(*std::next(std::begin(out), i));
+        const double r = type_convert<float>(*std::next(std::begin(ref), i));
+        err            = std::abs(o - r);
         if(err > atol + rtol * std::abs(r) || !std::isfinite(o) || !std::isfinite(r))
         {
             max_err = err > max_err ? err : max_err;
@@ -151,26 +164,17 @@ check_err(span<const T> out,
     return res;
 }
 
-template <typename T>
-typename std::enable_if<std::is_same<T, half_t>::value, bool>::type
-check_err(const std::vector<T>& out,
-          const std::vector<T>& ref,
-          const std::string& msg = "Error: Incorrect results!",
-          double rtol            = 1e-3,
-          double atol            = 1e-3)
-{
-    return check_err(span<const T>{out}, span<const T>{ref}, msg, rtol, atol);
-}
-
-template <typename T>
-std::enable_if_t<(std::is_integral_v<T> && !std::is_same_v<T, bhalf_t>)
+template <typename Range, typename RefRange>
+std::enable_if_t<(std::is_same_v<ranges::range_value_t<Range>, ranges::range_value_t<RefRange>> &&
+                  std::is_integral_v<ranges::range_value_t<Range>> &&
+                  !std::is_same_v<ranges::range_value_t<Range>, bhalf_t>)
 #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-                     || std::is_same_v<T, int4_t>
+                     || std::is_same_v<ranges::range_value_t<Range>, int4_t>
 #endif
                  ,
                  bool>
-check_err(const std::vector<T>& out,
-          const std::vector<T>& ref,
+check_err(const Range& out,
+          const RefRange& ref,
           const std::string& msg = "Error: Incorrect results!",
           double                 = 0,
           double atol            = 0)
@@ -188,9 +192,9 @@ check_err(const std::vector<T>& out,
     int64_t max_err = std::numeric_limits<int64_t>::min();
     for(std::size_t i = 0; i < ref.size(); ++i)
     {
-        int64_t o = out[i];
-        int64_t r = ref[i];
-        err       = std::abs(o - r);
+        const int64_t o = *std::next(std::begin(out), i);
+        const int64_t r = *std::next(std::begin(ref), i);
+        err             = std::abs(o - r);
 
         if(err > atol)
         {

--- a/library/include/ck/library/utility/device_memory.hpp
+++ b/library/include/ck/library/utility/device_memory.hpp
@@ -5,6 +5,8 @@
 
 #include <hip/hip_runtime.h>
 
+#include "ck/library/utility/buffer.hpp"
+
 template <typename T>
 __global__ void set_buffer_value(T* p, T x, uint64_t buffer_element_size)
 {
@@ -18,7 +20,7 @@ struct DeviceMem
 {
     DeviceMem() = delete;
     DeviceMem(std::size_t mem_size);
-    void* GetDeviceBuffer() const;
+    ck::utils::mutable_buffer GetDeviceBuffer() const;
     std::size_t GetBufferSize() const;
     void ToDevice(const void* p) const;
     void FromDevice(void* p) const;

--- a/library/include/ck/library/utility/fill.hpp
+++ b/library/include/ck/library/utility/fill.hpp
@@ -72,6 +72,16 @@ struct FillUniformDistributionIntegerValue
         std::generate(
             first, last, [&dis, &gen]() { return ck::type_convert<T>(std::round(dis(gen))); });
     }
+
+    template <typename ForwardRange>
+    auto operator()(ForwardRange&& range)
+        -> std::void_t<decltype(std::declval<FillUniformDistributionIntegerValue>()(
+            std::begin(std::forward<ForwardRange>(range)),
+            std::end(std::forward<ForwardRange>(range))))>
+    {
+        (*this)(std::begin(std::forward<ForwardRange>(range)),
+                std::end(std::forward<ForwardRange>(range)));
+    }
 };
 
 template <typename T>

--- a/library/include/ck/library/utility/host_conv.hpp
+++ b/library/include/ck/library/utility/host_conv.hpp
@@ -25,16 +25,15 @@ void host_conv_nchw_kcyx_nkhw(const Tensor<TIn>& in,
 
     auto f_nchw = [&](auto n, auto k, auto ho, auto wo) {
         float v = 0;
-        for(int c = 0; c < wei.mDesc.GetLengths()[1]; ++c)
+        for(int c = 0; c < wei.GetLengths()[1]; ++c)
         {
-            for(int y = 0; y < wei.mDesc.GetLengths()[2]; ++y)
+            for(int y = 0; y < wei.GetLengths()[2]; ++y)
             {
                 int hi = ho * conv_strides[I0] + y * conv_dilations[I0] - in_left_pads[I0];
-                for(int x = 0; x < wei.mDesc.GetLengths()[3]; ++x)
+                for(int x = 0; x < wei.GetLengths()[3]; ++x)
                 {
                     int wi = wo * conv_strides[I1] + x * conv_dilations[I1] - in_left_pads[I1];
-                    if(hi >= 0 && hi < in.mDesc.GetLengths()[2] && wi >= 0 &&
-                       wi < in.mDesc.GetLengths()[3])
+                    if(hi >= 0 && hi < in.GetLengths()[2] && wi >= 0 && wi < in.GetLengths()[3])
                     {
                         v += ck::type_convert<float>(in(n, c, hi, wi)) *
                              ck::type_convert<float>(wei(k, c, y, x));
@@ -45,11 +44,9 @@ void host_conv_nchw_kcyx_nkhw(const Tensor<TIn>& in,
         out(n, k, ho, wo) = ck::type_convert<TOut>(v);
     };
 
-    make_ParallelTensorFunctor(f_nchw,
-                               out.mDesc.GetLengths()[0],
-                               out.mDesc.GetLengths()[1],
-                               out.mDesc.GetLengths()[2],
-                               out.mDesc.GetLengths()[3])(std::thread::hardware_concurrency());
+    make_ParallelTensorFunctor(
+        f_nchw, out.GetLengths()[0], out.GetLengths()[1], out.GetLengths()[2], out.GetLengths()[3])(
+        std::thread::hardware_concurrency());
 }
 
 template <typename TIn,
@@ -72,13 +69,13 @@ void host_conv3d_ndhwc_kzyxc_ndhwk(const Tensor<TIn>& in,
     constexpr auto I0 = Number<0>{};
     constexpr auto I1 = Number<1>{};
     constexpr auto I2 = Number<2>{};
-    const auto Di     = in.mDesc.GetLengths()[1];
-    const auto Hi     = in.mDesc.GetLengths()[2];
-    const auto Wi     = in.mDesc.GetLengths()[3];
-    const auto Z      = wei.mDesc.GetLengths()[1];
-    const auto Y      = wei.mDesc.GetLengths()[2];
-    const auto X      = wei.mDesc.GetLengths()[3];
-    const auto C      = wei.mDesc.GetLengths()[4];
+    const auto Di     = in.GetLengths()[1];
+    const auto Hi     = in.GetLengths()[2];
+    const auto Wi     = in.GetLengths()[3];
+    const auto Z      = wei.GetLengths()[1];
+    const auto Y      = wei.GetLengths()[2];
+    const auto X      = wei.GetLengths()[3];
+    const auto C      = wei.GetLengths()[4];
 
     auto f_ndhwc = [&](auto n, auto do_tmp, auto ho_tmp, auto wo_tmp, auto k) {
         // do__ must be converted to signed integer, otherwise zmin might be wrong in cases
@@ -144,9 +141,9 @@ void host_conv3d_ndhwc_kzyxc_ndhwk(const Tensor<TIn>& in,
     };
 
     make_ParallelTensorFunctor(f_ndhwc,
-                               out.mDesc.GetLengths()[0],
-                               out.mDesc.GetLengths()[1],
-                               out.mDesc.GetLengths()[2],
-                               out.mDesc.GetLengths()[3],
-                               out.mDesc.GetLengths()[4])(std::thread::hardware_concurrency() - 4);
+                               out.GetLengths()[0],
+                               out.GetLengths()[1],
+                               out.GetLengths()[2],
+                               out.GetLengths()[3],
+                               out.GetLengths()[4])(std::thread::hardware_concurrency() - 4);
 }

--- a/library/include/ck/library/utility/host_gemm.hpp
+++ b/library/include/ck/library/utility/host_gemm.hpp
@@ -19,7 +19,7 @@ void host_gemm_mk_kn_mn(const Tensor<AType>& a_m_k,
                         const CElementwiseOperation& c_element_op)
 {
     auto f_mk_kn_mn = [&](auto m, auto n) {
-        const int K = a_m_k.mDesc.GetLengths()[1];
+        const int K = a_m_k.GetLengths()[1];
 
         float v_acc = 0;
 
@@ -41,7 +41,6 @@ void host_gemm_mk_kn_mn(const Tensor<AType>& a_m_k,
         c_m_n(m, n) = v_c;
     };
 
-    make_ParallelTensorFunctor(f_mk_kn_mn,
-                               c_m_n.mDesc.GetLengths()[0],
-                               c_m_n.mDesc.GetLengths()[1])(std::thread::hardware_concurrency());
+    make_ParallelTensorFunctor(f_mk_kn_mn, c_m_n.GetLengths()[0], c_m_n.GetLengths()[1])(
+        std::thread::hardware_concurrency());
 }

--- a/library/include/ck/library/utility/host_reduction.hpp
+++ b/library/include/ck/library/utility/host_reduction.hpp
@@ -108,13 +108,13 @@ struct ReductionHost
     std::vector<std::array<size_t, NumReduceDim>> reduce_dim_indexes;
     std::vector<std::array<size_t, NumInvariantDim>> invariant_dim_indexes;
 
-    ReductionHost(HostTensorDescriptor& inDesc,
-                  HostTensorDescriptor& outDesc,
+    ReductionHost(const HostTensorDescriptor& inDesc,
+                  const HostTensorDescriptor& outDesc,
                   const std::vector<int>& invariantDims_,
                   const std::vector<int>& reduceDims_)
     {
         // this->outLengths = to_int_vector(outDesc.GetLengths());
-        this->outStrides = outDesc.GetStrides();
+        this->outStrides.assign(outDesc.GetStrides().begin(), outDesc.GetStrides().end());
 
         this->invariantDims = invariantDims_;
         this->reduceDims    = reduceDims_;

--- a/library/include/ck/library/utility/iterator.hpp
+++ b/library/include/ck/library/utility/iterator.hpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <iterator>
+#include <utility>
+
+#include "ck/utility/type.hpp"
+
+namespace ck {
+
+template <typename T>
+using iter_value_t = typename std::iterator_traits<remove_cvref_t<T>>::value_type;
+
+template <typename T>
+using iter_reference_t = decltype(*std::declval<T&>());
+
+template <typename T>
+using iter_difference_t = typename std::iterator_traits<remove_cvref_t<T>>::difference_type;
+
+} // namespace ck

--- a/library/include/ck/library/utility/numeric.hpp
+++ b/library/include/ck/library/utility/numeric.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <iterator>
+#include <numeric>
+
+namespace ck {
+template <typename ForwardIterator, typename Size, typename T, typename BinaryOperation>
+auto accumulate_n(ForwardIterator first, Size count, T init, BinaryOperation op)
+    -> decltype(std::accumulate(first, std::next(first, count), init, op))
+{
+    return std::accumulate(first, std::next(first, count), init, op);
+}
+} // namespace ck

--- a/library/include/ck/library/utility/op_instance_engine.hpp
+++ b/library/include/ck/library/utility/op_instance_engine.hpp
@@ -103,8 +103,7 @@ class OpInstanceRunEngine
             }
         }
         AllocateDeviceInputTensors(std::make_index_sequence<kNInArgs_>{});
-        out_device_buffer_ = std::make_unique<DeviceMem>(sizeof(OutDataType) *
-                                                         out_tensor_->mDesc.GetElementSpaceSize());
+        out_device_buffer_ = std::make_unique<DeviceMem>(out_tensor_->GetMemorySize());
         out_device_buffer_->SetZero();
     }
 
@@ -219,10 +218,7 @@ class OpInstanceRunEngine
     void AllocateDeviceInputTensorsImpl()
     {
         const auto& ts = std::get<Index>(in_tensors_);
-        in_device_buffers_
-            .emplace_back(
-                std::make_unique<DeviceMem>(sizeof(std::tuple_element_t<Index, InArgsTypesTuple>) *
-                                            ts->mDesc.GetElementSpaceSize()))
+        in_device_buffers_.emplace_back(std::make_unique<DeviceMem>(ts->GetMemorySize()))
             ->ToDevice(ts->mData.data());
     }
 

--- a/library/include/ck/library/utility/ranges.hpp
+++ b/library/include/ck/library/utility/ranges.hpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include "ck/library/utility/iterator.hpp"
+
+namespace ck {
+namespace ranges {
+
+template <typename R>
+using iterator_t = decltype(std::begin(std::declval<R&>()));
+
+template <typename R>
+using sentinel_t = decltype(std::end(std::declval<R&>()));
+
+template <typename R>
+using range_size_t = decltype(std::size(std::declval<R&>()));
+
+template <typename R>
+using range_difference_t = ck::iter_difference_t<ranges::iterator_t<R>>;
+
+template <typename R>
+using range_value_t = iter_value_t<ranges::iterator_t<R>>;
+
+template <typename R>
+using range_reference_t = iter_reference_t<ranges::iterator_t<R>>;
+
+template <typename T, typename = void>
+struct is_range : std::false_type
+{
+};
+
+template <typename T>
+struct is_range<
+    T,
+    std::void_t<decltype(std::begin(std::declval<T&>())), decltype(std::end(std::declval<T&>()))>>
+    : std::true_type
+{
+};
+
+template <typename T>
+inline constexpr bool is_range_v = is_range<T>::value;
+
+template <typename T, typename = void>
+struct is_sized_range : std::false_type
+{
+};
+
+template <typename T>
+struct is_sized_range<T, std::void_t<decltype(std::size(std::declval<T&>()))>>
+    : std::bool_constant<is_range_v<T>>
+{
+};
+
+template <typename T>
+inline constexpr bool is_sized_range_v = is_sized_range<T>::value;
+
+template <typename Cont, typename Range, typename... Args>
+auto to(Range&& range, Args&&... args) -> decltype(Cont{std::begin(std::forward<Range>(range)),
+                                                        std::end(std::forward<Range>(range)),
+                                                        std::forward<Args>(args)...})
+{
+    return Cont{std::begin(std::forward<Range>(range)),
+                std::end(std::forward<Range>(range)),
+                std::forward<Args>(args)...};
+}
+} // namespace ranges
+} // namespace ck

--- a/library/src/utility/device_memory.cpp
+++ b/library/src/utility/device_memory.cpp
@@ -10,7 +10,10 @@ DeviceMem::DeviceMem(std::size_t mem_size) : mMemSize(mem_size)
     hip_check_error(hipMalloc(static_cast<void**>(&mpDeviceBuf), mMemSize));
 }
 
-void* DeviceMem::GetDeviceBuffer() const { return mpDeviceBuf; }
+ck::utils::mutable_buffer DeviceMem::GetDeviceBuffer() const
+{
+    return ck::utils::mutable_buffer(mpDeviceBuf, mMemSize);
+}
 
 std::size_t DeviceMem::GetBufferSize() const { return mMemSize; }
 

--- a/library/src/utility/host_tensor.cpp
+++ b/library/src/utility/host_tensor.cpp
@@ -36,9 +36,9 @@ std::size_t HostTensorDescriptor::GetElementSpaceSize() const
     return space;
 }
 
-const std::vector<std::size_t>& HostTensorDescriptor::GetLengths() const { return mLens; }
+ck::span<const std::size_t> HostTensorDescriptor::GetLengths() const { return mLens; }
 
-const std::vector<std::size_t>& HostTensorDescriptor::GetStrides() const { return mStrides; }
+ck::span<const std::size_t> HostTensorDescriptor::GetStrides() const { return mStrides; }
 
 std::ostream& operator<<(std::ostream& os, const HostTensorDescriptor& desc)
 {

--- a/profiler/include/profile_batched_gemm_add_relu_gemm_add_impl.hpp
+++ b/profiler/include/profile_batched_gemm_add_relu_gemm_add_impl.hpp
@@ -8,13 +8,16 @@
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm_add_relu_gemm_add.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
+#include "ck/library/utility/array.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace profiler {
@@ -105,21 +108,21 @@ bool profile_batched_gemm_add_relu_gemm_add_impl(bool do_verification,
     BatchStrideD1 = BatchStrideD1 < 0 ? DefaultBatchStrideD1 : BatchStrideD1;
     BatchStrideE1 = BatchStrideE1 < 0 ? DefaultBatchStrideE1 : BatchStrideE1;
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor = [](std::size_t batch_count,
                                        std::size_t row,
                                        std::size_t col,
                                        std::size_t stride,
                                        std::size_t batch_stride,
                                        auto layout) {
-        if(std::is_same<decltype(layout), Row>::value)
+        if constexpr(std::is_same_v<decltype(layout), Row>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, stride, 1}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, 1, stride}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, 1_uz, stride});
         }
     };
 
@@ -144,12 +147,12 @@ bool profile_batched_gemm_add_relu_gemm_add_impl(bool do_verification,
     Tensor<RefAcc0DataType> e0_g_m_n(f_host_tensor_descriptor(BatchCount, M, N, N, M * N, Row{}));
     Tensor<RefAcc1DataType> c1_g_m_o(f_host_tensor_descriptor(BatchCount, M, O, O, M * O, Row{}));
 
-    std::cout << "a0_g_m_k: " << a0_g_m_k.mDesc << std::endl;
-    std::cout << "b0_g_k_n: " << b0_g_k_n.mDesc << std::endl;
-    std::cout << "d0_g_m_n: " << d0_g_m_n.mDesc << std::endl;
-    std::cout << "b1_g_n_o: " << b1_g_n_o.mDesc << std::endl;
-    std::cout << "d1_g_m_o: " << d1_g_m_o.mDesc << std::endl;
-    std::cout << "e1_g_m_o: " << e1_g_m_o_host_result.mDesc << std::endl;
+    std::cout << "a0_g_m_k: " << a0_g_m_k.GetDesc() << std::endl;
+    std::cout << "b0_g_k_n: " << b0_g_k_n.GetDesc() << std::endl;
+    std::cout << "d0_g_m_n: " << d0_g_m_n.GetDesc() << std::endl;
+    std::cout << "b1_g_n_o: " << b1_g_n_o.GetDesc() << std::endl;
+    std::cout << "d1_g_m_o: " << d1_g_m_o.GetDesc() << std::endl;
+    std::cout << "e1_g_m_o: " << e1_g_m_o_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -169,19 +172,18 @@ bool profile_batched_gemm_add_relu_gemm_add_impl(bool do_verification,
         d1_g_m_o.GenerateTensorValue(GeneratorTensor_3<D1DataType>{0.0, 1.0});
     }
 
-    DeviceMem a0_g_m_k_device_buf(sizeof(A0DataType) * a0_g_m_k.mDesc.GetElementSize());
-    DeviceMem b0_g_k_n_device_buf(sizeof(B0DataType) * b0_g_k_n.mDesc.GetElementSize());
-    DeviceMem d0_g_m_n_device_buf(sizeof(D0DataType) * d0_g_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem b1_g_n_o_device_buf(sizeof(B1DataType) * b1_g_n_o.mDesc.GetElementSize());
-    DeviceMem d1_g_m_o_device_buf(sizeof(D1DataType) * d1_g_m_o.mDesc.GetElementSpaceSize());
-    DeviceMem e1_g_m_o_device_buf(sizeof(E1DataType) *
-                                  e1_g_m_o_device_result.mDesc.GetElementSize());
+    DeviceMem a0_g_m_k_device_buf(a0_g_m_k.GetMemorySize());
+    DeviceMem b0_g_k_n_device_buf(b0_g_k_n.GetMemorySize());
+    DeviceMem d0_g_m_n_device_buf(d0_g_m_n.GetMemorySize());
+    DeviceMem b1_g_n_o_device_buf(b1_g_n_o.GetMemorySize());
+    DeviceMem d1_g_m_o_device_buf(d1_g_m_o.GetMemorySize());
+    DeviceMem e1_g_m_o_device_buf(e1_g_m_o_device_result.GetMemorySize());
 
-    a0_g_m_k_device_buf.ToDevice(a0_g_m_k.mData.data());
-    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.mData.data());
-    d0_g_m_n_device_buf.ToDevice(d0_g_m_n.mData.data());
-    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.mData.data());
-    d1_g_m_o_device_buf.ToDevice(d1_g_m_o.mData.data());
+    a0_g_m_k_device_buf.ToDevice(a0_g_m_k.data());
+    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.data());
+    d0_g_m_n_device_buf.ToDevice(d0_g_m_n.data());
+    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.data());
+    d1_g_m_o_device_buf.ToDevice(d1_g_m_o.data());
 
     auto a0_element_op   = A0ElementOp{};
     auto b0_element_op   = B0ElementOp{};
@@ -263,38 +265,40 @@ bool profile_batched_gemm_add_relu_gemm_add_impl(bool do_verification,
     float best_tflops     = 0;
     float best_gb_per_sec = 0;
 
+    using ck::utils::to_array;
+
     // profile device op instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<A0DataType*>(a0_g_m_k_device_buf.GetDeviceBuffer()),
-            static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-            std::array<const void*, 1>{d0_g_m_n_device_buf.GetDeviceBuffer()},
-            static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-            std::array<const void*, 1>{d1_g_m_o_device_buf.GetDeviceBuffer()},
-            static_cast<E1DataType*>(e1_g_m_o_device_buf.GetDeviceBuffer()),
-            M,
-            N,
-            K,
-            O,
-            BatchCount,
-            StrideA0,
-            StrideB0,
-            std::array<ck::index_t, 1>{StrideD0},
-            StrideB1,
-            std::array<ck::index_t, 1>{StrideD1},
-            StrideE1,
-            BatchStrideA0,
-            BatchStrideB0,
-            std::array<ck::index_t, 1>{BatchStrideD0},
-            BatchStrideB1,
-            std::array<ck::index_t, 1>{BatchStrideD1},
-            BatchStrideE1,
-            a0_element_op,
-            b0_element_op,
-            cde0_element_op,
-            b1_element_op,
-            cde1_element_op);
+        auto argument_ptr =
+            op_ptr->MakeArgumentPointer(a0_g_m_k_device_buf.GetDeviceBuffer(),
+                                        b0_g_k_n_device_buf.GetDeviceBuffer(),
+                                        to_array({d0_g_m_n_device_buf.GetDeviceBuffer()}),
+                                        b1_g_n_o_device_buf.GetDeviceBuffer(),
+                                        to_array({d1_g_m_o_device_buf.GetDeviceBuffer()}),
+                                        e1_g_m_o_device_buf.GetDeviceBuffer(),
+                                        M,
+                                        N,
+                                        K,
+                                        O,
+                                        BatchCount,
+                                        StrideA0,
+                                        StrideB0,
+                                        to_array({StrideD0}),
+                                        StrideB1,
+                                        to_array({StrideD1}),
+                                        StrideE1,
+                                        BatchStrideA0,
+                                        BatchStrideB0,
+                                        to_array({BatchStrideD0}),
+                                        BatchStrideB1,
+                                        to_array({BatchStrideD1}),
+                                        BatchStrideE1,
+                                        a0_element_op,
+                                        b0_element_op,
+                                        cde0_element_op,
+                                        b1_element_op,
+                                        cde1_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 
@@ -328,18 +332,17 @@ bool profile_batched_gemm_add_relu_gemm_add_impl(bool do_verification,
 
             if(do_verification)
             {
-                e1_g_m_o_device_buf.FromDevice(e1_g_m_o_device_result.mData.data());
+                e1_g_m_o_device_buf.FromDevice(e1_g_m_o_device_result.data());
 
-                pass = pass & ck::utils::check_err(e1_g_m_o_device_result.mData,
-                                                   e1_g_m_o_host_result.mData);
+                pass = pass & ck::utils::check_err(e1_g_m_o_device_result, e1_g_m_o_host_result);
 
                 if(do_log)
                 {
                     LogRangeAsType<float>(
-                        std::cout << "e1_g_m_o_host_result : ", e1_g_m_o_host_result.mData, ",")
+                        std::cout << "e1_g_m_o_host_result : ", e1_g_m_o_host_result, ",")
                         << std::endl;
                     LogRangeAsType<float>(
-                        std::cout << "e1_g_m_o_device_result : ", e1_g_m_o_device_result.mData, ",")
+                        std::cout << "e1_g_m_o_device_result : ", e1_g_m_o_device_result, ",")
                         << std::endl;
                 }
             }

--- a/profiler/include/profile_batched_gemm_gemm_impl.hpp
+++ b/profiler/include/profile_batched_gemm_gemm_impl.hpp
@@ -6,17 +6,18 @@
 #include <memory>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm_gemm.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace profiler {
@@ -99,21 +100,21 @@ bool profile_batched_gemm_gemm_impl(bool do_verification,
     BatchStrideB1 = BatchStrideB1 < 0 ? DefaultBatchStrideB1 : BatchStrideB1;
     BatchStrideC  = BatchStrideC < 0 ? DefaultBatchStrideC : BatchStrideC;
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor = [](std::size_t batch_count,
                                        std::size_t row,
                                        std::size_t col,
                                        std::size_t stride,
                                        std::size_t batch_stride,
                                        auto layout) {
-        if(std::is_same<decltype(layout), Row>::value)
+        if constexpr(std::is_same_v<decltype(layout), Row>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, stride, 1}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, 1, stride}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, 1_uz, stride});
         }
     };
 
@@ -131,10 +132,10 @@ bool profile_batched_gemm_gemm_impl(bool do_verification,
     // Host verification: Output of Gemm0 is input A of Gemm1
     Tensor<ADataType> acc0_g_m_n(f_host_tensor_descriptor(BatchCount, M, N, N, M * N, Row{}));
 
-    std::cout << "a_g_m_k: " << a_g_m_k.mDesc << std::endl;
-    std::cout << "b0_g_k_n: " << b0_g_k_n.mDesc << std::endl;
-    std::cout << "b1_g_n_o: " << b1_g_n_o.mDesc << std::endl;
-    std::cout << "c_g_m_o: " << c_g_m_o_host_result.mDesc << std::endl;
+    std::cout << "a_g_m_k: " << a_g_m_k.GetDesc() << std::endl;
+    std::cout << "b0_g_k_n: " << b0_g_k_n.GetDesc() << std::endl;
+    std::cout << "b1_g_n_o: " << b1_g_n_o.GetDesc() << std::endl;
+    std::cout << "c_g_m_o: " << c_g_m_o_host_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -160,14 +161,14 @@ bool profile_batched_gemm_gemm_impl(bool do_verification,
         b1_g_n_o.GenerateTensorValue(GeneratorTensor_Diagonal<B1DataType>{});
     }
 
-    DeviceMem a_g_m_k_device_buf(sizeof(ADataType) * a_g_m_k.mDesc.GetElementSize());
-    DeviceMem b0_g_k_n_device_buf(sizeof(B0DataType) * b0_g_k_n.mDesc.GetElementSize());
-    DeviceMem b1_g_n_o_device_buf(sizeof(B1DataType) * b1_g_n_o.mDesc.GetElementSize());
-    DeviceMem c_g_m_o_device_buf(sizeof(CDataType) * c_g_m_o_device_result.mDesc.GetElementSize());
+    DeviceMem a_g_m_k_device_buf(a_g_m_k.GetMemorySize());
+    DeviceMem b0_g_k_n_device_buf(b0_g_k_n.GetMemorySize());
+    DeviceMem b1_g_n_o_device_buf(b1_g_n_o.GetMemorySize());
+    DeviceMem c_g_m_o_device_buf(c_g_m_o_device_result.GetMemorySize());
 
-    a_g_m_k_device_buf.ToDevice(a_g_m_k.mData.data());
-    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.mData.data());
-    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.mData.data());
+    a_g_m_k_device_buf.ToDevice(a_g_m_k.data());
+    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.data());
+    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.data());
 
     auto a_element_op    = AElementOp{};
     auto b0_element_op   = B0ElementOp{};
@@ -226,29 +227,28 @@ bool profile_batched_gemm_gemm_impl(bool do_verification,
     // profile device op instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-            static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-            static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-            static_cast<CDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-            M,
-            N,
-            K,
-            O,
-            BatchCount,
-            StrideA,
-            StrideB0,
-            StrideB1,
-            StrideC,
-            BatchStrideA,
-            BatchStrideB0,
-            BatchStrideB1,
-            BatchStrideC,
-            a_element_op,
-            b0_element_op,
-            acc0_element_op,
-            b1_element_op,
-            c_element_op);
+        auto argument_ptr = op_ptr->MakeArgumentPointer(a_g_m_k_device_buf.GetDeviceBuffer(),
+                                                        b0_g_k_n_device_buf.GetDeviceBuffer(),
+                                                        b1_g_n_o_device_buf.GetDeviceBuffer(),
+                                                        c_g_m_o_device_buf.GetDeviceBuffer(),
+                                                        M,
+                                                        N,
+                                                        K,
+                                                        O,
+                                                        BatchCount,
+                                                        StrideA,
+                                                        StrideB0,
+                                                        StrideB1,
+                                                        StrideC,
+                                                        BatchStrideA,
+                                                        BatchStrideB0,
+                                                        BatchStrideB1,
+                                                        BatchStrideC,
+                                                        a_element_op,
+                                                        b0_element_op,
+                                                        acc0_element_op,
+                                                        b1_element_op,
+                                                        c_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 
@@ -281,24 +281,20 @@ bool profile_batched_gemm_gemm_impl(bool do_verification,
 
             if(do_verification)
             {
-                c_g_m_o_device_buf.FromDevice(c_g_m_o_device_result.mData.data());
+                c_g_m_o_device_buf.FromDevice(c_g_m_o_device_result.data());
 
-                pass = pass &
-                       ck::utils::check_err(c_g_m_o_device_result.mData, c_g_m_o_host_result.mData);
+                pass = pass & ck::utils::check_err(c_g_m_o_device_result, c_g_m_o_host_result);
 
                 if(do_log)
                 {
-                    LogRangeAsType<float>(std::cout << "a_g_m_k: ", a_g_m_k.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(std::cout << "b0_g_k_n : ", b0_g_k_n.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(std::cout << "b1_g_n_o : ", b1_g_n_o.mData, ",")
+                    LogRangeAsType<float>(std::cout << "a_g_m_k: ", a_g_m_k, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "b0_g_k_n : ", b0_g_k_n, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "b1_g_n_o : ", b1_g_n_o, ",") << std::endl;
+                    LogRangeAsType<float>(
+                        std::cout << "c_g_m_o_host_result : ", c_g_m_o_host_result, ",")
                         << std::endl;
                     LogRangeAsType<float>(
-                        std::cout << "c_g_m_o_host_result : ", c_g_m_o_host_result.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(
-                        std::cout << "c_g_m_o_device_result : ", c_g_m_o_device_result.mData, ",")
+                        std::cout << "c_g_m_o_device_result : ", c_g_m_o_device_result, ",")
                         << std::endl;
                 }
             }

--- a/profiler/include/profile_batched_gemm_masking_scale_softmax_gemm_permute_impl.hpp
+++ b/profiler/include/profile_batched_gemm_masking_scale_softmax_gemm_permute_impl.hpp
@@ -6,18 +6,19 @@
 #include <memory>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_softmax_gemm_permute_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm_masking_scale_softmax_gemm_permute.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
+#include "ck/library/reference_tensor_operation/cpu/reference_softmax.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_batched_gemm.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_softmax.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace profiler {
@@ -106,21 +107,21 @@ bool profile_batched_gemm_masking_scale_softmax_gemm_permute_impl(bool do_verifi
 
     const int BatchCount = G0 * G1;
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor = [](std::size_t batch_count,
                                        std::size_t row,
                                        std::size_t col,
                                        std::size_t stride,
                                        std::size_t batch_stride,
                                        auto layout) {
-        if(std::is_same<decltype(layout), Row>::value)
+        if constexpr(std::is_same_v<decltype(layout), Row>)
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, stride, 1}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, stride, 1_uz});
         }
         else
         {
-            return HostTensorDescriptor(std::vector<std::size_t>({batch_count, row, col}),
-                                        std::vector<std::size_t>({batch_stride, 1, stride}));
+            return HostTensorDescriptor({batch_count, row, col}, {batch_stride, 1_uz, stride});
         }
     };
 
@@ -131,22 +132,17 @@ bool profile_batched_gemm_masking_scale_softmax_gemm_permute_impl(bool do_verifi
         f_host_tensor_descriptor(BatchCount, K, N, StrideB0, BatchStrideB0, B0Layout{}));
     Tensor<B1DataType> b1_g_n_o(
         f_host_tensor_descriptor(BatchCount, N, O, StrideB1, BatchStrideB1, B1Layout{}));
-    Tensor<CDataType> c_gs_ms_os_host_result(
-        std::vector<std::size_t>(c_gs_ms_os_lengths.begin(), c_gs_ms_os_lengths.end()),
-        std::vector<std::size_t>(c_gs_ms_os_strides.begin(), c_gs_ms_os_strides.end()));
-    Tensor<CDataType> c_gs_ms_os_device_result(
-        std::vector<std::size_t>(c_gs_ms_os_lengths.begin(), c_gs_ms_os_lengths.end()),
-        std::vector<std::size_t>(c_gs_ms_os_strides.begin(), c_gs_ms_os_strides.end()));
+    Tensor<CDataType> c_gs_ms_os_host_result(c_gs_ms_os_lengths, c_gs_ms_os_strides);
+    Tensor<CDataType> c_gs_ms_os_device_result(c_gs_ms_os_lengths, c_gs_ms_os_strides);
     // Host verification: Output of Gemm0 is input A of Gemm1
     Tensor<AccDataType> acc0_g_m_n(f_host_tensor_descriptor(BatchCount, M, N, N, M * N, Row{}));
     Tensor<ADataType> a1_g_m_n(f_host_tensor_descriptor(BatchCount, M, N, N, M * N, Row{}));
-    Tensor<CDataType> c_g_m_o_host_result(std::vector<int>{BatchCount, M, O},
-                                          std::vector<int>{M * O, O, 1});
+    Tensor<CDataType> c_g_m_o_host_result({BatchCount, M, O}, {M * O, O, 1});
 
-    std::cout << "a_g_m_k: " << a_g_m_k.mDesc << std::endl;
-    std::cout << "b0_g_k_n: " << b0_g_k_n.mDesc << std::endl;
-    std::cout << "b1_g_n_o: " << b1_g_n_o.mDesc << std::endl;
-    std::cout << "c_gs_ms_os: " << c_gs_ms_os_host_result.mDesc << std::endl;
+    std::cout << "a_g_m_k: " << a_g_m_k.GetDesc() << std::endl;
+    std::cout << "b0_g_k_n: " << b0_g_k_n.GetDesc() << std::endl;
+    std::cout << "b1_g_n_o: " << b1_g_n_o.GetDesc() << std::endl;
+    std::cout << "c_gs_ms_os: " << c_gs_ms_os_host_result.GetDesc() << std::endl;
 
     std::srand(1); // work around test flakiness
     switch(init_method)
@@ -180,15 +176,14 @@ bool profile_batched_gemm_masking_scale_softmax_gemm_permute_impl(bool do_verifi
         b1_g_n_o.GenerateTensorValue(GeneratorTensor_Diagonal<B1DataType>{});
     }
 
-    DeviceMem a_g_m_k_device_buf(sizeof(ADataType) * a_g_m_k.mDesc.GetElementSize());
-    DeviceMem b0_g_k_n_device_buf(sizeof(B0DataType) * b0_g_k_n.mDesc.GetElementSize());
-    DeviceMem b1_g_n_o_device_buf(sizeof(B1DataType) * b1_g_n_o.mDesc.GetElementSize());
-    DeviceMem c_gs_ms_os_device_buf(sizeof(CDataType) *
-                                    c_gs_ms_os_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_g_m_k_device_buf(a_g_m_k.GetMemorySize());
+    DeviceMem b0_g_k_n_device_buf(b0_g_k_n.GetMemorySize());
+    DeviceMem b1_g_n_o_device_buf(b1_g_n_o.GetMemorySize());
+    DeviceMem c_gs_ms_os_device_buf(c_gs_ms_os_device_result.GetMemorySize());
 
-    a_g_m_k_device_buf.ToDevice(a_g_m_k.mData.data());
-    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.mData.data());
-    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.mData.data());
+    a_g_m_k_device_buf.ToDevice(a_g_m_k.data());
+    b0_g_k_n_device_buf.ToDevice(b0_g_k_n.data());
+    b1_g_n_o_device_buf.ToDevice(b1_g_n_o.data());
 
     auto a_element_op    = AElementOp{};
     auto b0_element_op   = B0ElementOp{};
@@ -264,29 +259,28 @@ bool profile_batched_gemm_masking_scale_softmax_gemm_permute_impl(bool do_verifi
     // profile device op instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-            static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-            static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-            static_cast<CDataType*>(c_gs_ms_os_device_buf.GetDeviceBuffer()),
-            M,
-            N,
-            K,
-            O,
-            BatchCount,
-            c_gs_ms_os_lengths,
-            c_gs_ms_os_strides,
-            StrideA,
-            StrideB0,
-            StrideB1,
-            BatchStrideA,
-            BatchStrideB0,
-            BatchStrideB1,
-            a_element_op,
-            b0_element_op,
-            acc0_element_op,
-            b1_element_op,
-            c_element_op);
+        auto argument_ptr = op_ptr->MakeArgumentPointer(a_g_m_k_device_buf.GetDeviceBuffer(),
+                                                        b0_g_k_n_device_buf.GetDeviceBuffer(),
+                                                        b1_g_n_o_device_buf.GetDeviceBuffer(),
+                                                        c_gs_ms_os_device_buf.GetDeviceBuffer(),
+                                                        M,
+                                                        N,
+                                                        K,
+                                                        O,
+                                                        BatchCount,
+                                                        c_gs_ms_os_lengths,
+                                                        c_gs_ms_os_strides,
+                                                        StrideA,
+                                                        StrideB0,
+                                                        StrideB1,
+                                                        BatchStrideA,
+                                                        BatchStrideB0,
+                                                        BatchStrideB1,
+                                                        a_element_op,
+                                                        b0_element_op,
+                                                        acc0_element_op,
+                                                        b1_element_op,
+                                                        c_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 
@@ -319,25 +313,21 @@ bool profile_batched_gemm_masking_scale_softmax_gemm_permute_impl(bool do_verifi
 
             if(do_verification)
             {
-                c_gs_ms_os_device_buf.FromDevice(c_gs_ms_os_device_result.mData.data());
+                c_gs_ms_os_device_buf.FromDevice(c_gs_ms_os_device_result.data());
 
-                pass = pass & ck::utils::check_err(c_gs_ms_os_device_result.mData,
-                                                   c_gs_ms_os_host_result.mData);
+                pass =
+                    pass & ck::utils::check_err(c_gs_ms_os_device_result, c_gs_ms_os_host_result);
 
                 if(do_log)
                 {
-                    LogRangeAsType<float>(std::cout << "a_g_m_k: ", a_g_m_k.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(std::cout << "b0_g_k_n : ", b0_g_k_n.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(std::cout << "b1_g_n_o : ", b1_g_n_o.mData, ",")
+                    LogRangeAsType<float>(std::cout << "a_g_m_k: ", a_g_m_k, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "b0_g_k_n : ", b0_g_k_n, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "b1_g_n_o : ", b1_g_n_o, ",") << std::endl;
+                    LogRangeAsType<float>(
+                        std::cout << "c_gs_ms_os_host_result : ", c_gs_ms_os_host_result, ",")
                         << std::endl;
                     LogRangeAsType<float>(
-                        std::cout << "c_gs_ms_os_host_result : ", c_gs_ms_os_host_result.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(std::cout << "c_gs_ms_os_device_result : ",
-                                          c_gs_ms_os_device_result.mData,
-                                          ",")
+                        std::cout << "c_gs_ms_os_device_result : ", c_gs_ms_os_device_result, ",")
                         << std::endl;
                 }
             }

--- a/profiler/include/profile_batched_gemm_reduce_impl.hpp
+++ b/profiler/include/profile_batched_gemm_reduce_impl.hpp
@@ -96,13 +96,13 @@ bool profile_batched_gemm_reduce_impl(int do_verification,
 
     Tensor<CDataType> c_g_m_n_host_result(
         f_host_tensor_descriptor(BatchCount, M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> d0_g_m_host_result(HostTensorDescriptor({BatchCount, M}));
-    Tensor<ReduceDataType> d1_g_m_host_result(HostTensorDescriptor({BatchCount, M}));
+    Tensor<ReduceDataType> d0_g_m_host_result({BatchCount, M});
+    Tensor<ReduceDataType> d1_g_m_host_result({BatchCount, M});
 
     Tensor<CDataType> c_g_m_n_device_result(
         f_host_tensor_descriptor(BatchCount, M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> d0_g_m_device_result(HostTensorDescriptor({BatchCount, M}));
-    Tensor<ReduceDataType> d1_g_m_device_result(HostTensorDescriptor({BatchCount, M}));
+    Tensor<ReduceDataType> d0_g_m_device_result({BatchCount, M});
+    Tensor<ReduceDataType> d1_g_m_device_result({BatchCount, M});
 
     std::cout << "a_g_m_k: " << a_g_m_k.GetDesc() << std::endl;
     std::cout << "b_g_k_n: " << b_g_k_n.GetDesc() << std::endl;

--- a/profiler/include/profile_conv_fwd_bias_relu_add_impl.hpp
+++ b/profiler/include/profile_conv_fwd_bias_relu_add_impl.hpp
@@ -4,15 +4,16 @@
 #pragma once
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation_add.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation_add.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation_add.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace tensor_operation {
@@ -66,21 +67,21 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
     const ck::index_t Ho = output_spatial_lengths[0];
     const ck::index_t Wo = output_spatial_lengths[1];
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t N_, std::size_t C_, std::size_t H, std::size_t W, auto layout) {
-            if constexpr(is_same<decltype(layout), ck::tensor_layout::convolution::NCHW>::value ||
-                         is_same<decltype(layout), ck::tensor_layout::convolution::KCYX>::value ||
-                         is_same<decltype(layout), ck::tensor_layout::convolution::NKHW>::value)
+            if constexpr(is_same_v<decltype(layout), ck::tensor_layout::convolution::NCHW> ||
+                         is_same_v<decltype(layout), ck::tensor_layout::convolution::KCYX> ||
+                         is_same_v<decltype(layout), ck::tensor_layout::convolution::NKHW>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({N_, C_, H, W}),
-                                            std::vector<std::size_t>({C_ * H * W, H * W, W, 1}));
+                return HostTensorDescriptor({N_, C_, H, W}, {C_ * H * W, H * W, W, 1_uz});
             }
-            else if constexpr(is_same<decltype(layout), tensor_layout::convolution::NHWC>::value ||
-                              is_same<decltype(layout), tensor_layout::convolution::KYXC>::value ||
-                              is_same<decltype(layout), tensor_layout::convolution::NHWK>::value)
+            else if constexpr(is_same_v<decltype(layout), tensor_layout::convolution::NHWC> ||
+                              is_same_v<decltype(layout), tensor_layout::convolution::KYXC> ||
+                              is_same_v<decltype(layout), tensor_layout::convolution::NHWK>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({N_, C_, H, W}),
-                                            std::vector<std::size_t>({C_ * H * W, 1, W * C_, C_}));
+                return HostTensorDescriptor({N_, C_, H, W}, {C_ * H * W, 1_uz, W * C_, C_});
             }
         };
 
@@ -92,17 +93,16 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
         f_host_tensor_descriptor(N, K, Ho, Wo, OutLayout{}));
 
     // bias: assume contiguous 1d vector
-    Tensor<OutDataType> bias_k(
-        HostTensorDescriptor(std::vector<std::size_t>({static_cast<std::size_t>(K)})));
+    Tensor<OutDataType> bias_k(HostTensorDescriptor({K}));
 
     // residual: assume same layout as output tensor
     Tensor<OutDataType> resi_n_k_ho_wo(f_host_tensor_descriptor(N, K, Ho, Wo, OutLayout{}));
 
-    std::cout << "in_n_c_hi_wi: " << in_n_c_hi_wi.mDesc << std::endl;
-    std::cout << "wei_k_c_y_x: " << wei_k_c_y_x.mDesc << std::endl;
-    std::cout << "out_n_k_ho_wo: " << out_n_k_ho_wo_host_result.mDesc << std::endl;
-    std::cout << "bias_k: " << bias_k.mDesc << std::endl;
-    std::cout << "resi_n_k_ho_wo: " << resi_n_k_ho_wo.mDesc << std::endl;
+    std::cout << "in_n_c_hi_wi: " << in_n_c_hi_wi.GetDesc() << std::endl;
+    std::cout << "wei_k_c_y_x: " << wei_k_c_y_x.GetDesc() << std::endl;
+    std::cout << "out_n_k_ho_wo: " << out_n_k_ho_wo_host_result.GetDesc() << std::endl;
+    std::cout << "bias_k: " << bias_k.GetDesc() << std::endl;
+    std::cout << "resi_n_k_ho_wo: " << resi_n_k_ho_wo.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -157,17 +157,16 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
         ref_invoker.Run(ref_argument);
     }
 
-    DeviceMem in_device_buf(sizeof(InDataType) * in_n_c_hi_wi.mDesc.GetElementSpaceSize());
-    DeviceMem wei_device_buf(sizeof(WeiDataType) * wei_k_c_y_x.mDesc.GetElementSpaceSize());
-    DeviceMem out_device_buf(sizeof(OutDataType) *
-                             out_n_k_ho_wo_device_result.mDesc.GetElementSpaceSize());
-    DeviceMem bias_device_buf(sizeof(OutDataType) * bias_k.mDesc.GetElementSpaceSize());
-    DeviceMem resi_device_buf(sizeof(OutDataType) * resi_n_k_ho_wo.mDesc.GetElementSpaceSize());
+    DeviceMem in_device_buf(in_n_c_hi_wi.GetMemorySize());
+    DeviceMem wei_device_buf(wei_k_c_y_x.GetMemorySize());
+    DeviceMem out_device_buf(out_n_k_ho_wo_device_result.GetMemorySize());
+    DeviceMem bias_device_buf(bias_k.GetMemorySize());
+    DeviceMem resi_device_buf(resi_n_k_ho_wo.GetMemorySize());
 
-    in_device_buf.ToDevice(in_n_c_hi_wi.mData.data());
-    wei_device_buf.ToDevice(wei_k_c_y_x.mData.data());
-    bias_device_buf.ToDevice(bias_k.mData.data());
-    resi_device_buf.ToDevice(resi_n_k_ho_wo.mData.data());
+    in_device_buf.ToDevice(in_n_c_hi_wi.data());
+    wei_device_buf.ToDevice(wei_k_c_y_x.data());
+    bias_device_buf.ToDevice(bias_k.data());
+    resi_device_buf.ToDevice(resi_n_k_ho_wo.data());
 
     using DeviceConvFwdBiasReluAddPtr = ck::tensor_operation::device::
         DeviceConvFwdBiasActivationAddPtr<InElementOp, WeiElementOp, OutElementOp>;
@@ -196,25 +195,24 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
     // profile device Conv instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<const InDataType*>(in_device_buf.GetDeviceBuffer()),
-            static_cast<const WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-            static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
-            static_cast<const OutDataType*>(bias_device_buf.GetDeviceBuffer()),
-            static_cast<const OutDataType*>(resi_device_buf.GetDeviceBuffer()),
-            N,
-            K,
-            C,
-            input_spatial_lengths,
-            filter_spatial_lengths,
-            output_spatial_lengths,
-            conv_filter_strides,
-            conv_filter_dilations,
-            input_left_pads,
-            input_right_pads,
-            in_element_op,
-            wei_element_op,
-            out_element_op);
+        auto argument_ptr = op_ptr->MakeArgumentPointer(in_device_buf.GetDeviceBuffer(),
+                                                        wei_device_buf.GetDeviceBuffer(),
+                                                        out_device_buf.GetDeviceBuffer(),
+                                                        bias_device_buf.GetDeviceBuffer(),
+                                                        resi_device_buf.GetDeviceBuffer(),
+                                                        N,
+                                                        K,
+                                                        C,
+                                                        input_spatial_lengths,
+                                                        filter_spatial_lengths,
+                                                        output_spatial_lengths,
+                                                        conv_filter_strides,
+                                                        conv_filter_dilations,
+                                                        input_left_pads,
+                                                        input_right_pads,
+                                                        in_element_op,
+                                                        wei_element_op,
+                                                        out_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 
@@ -225,7 +223,7 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
             float ave_time =
                 invoker_ptr->Run(argument_ptr.get(), StreamConfig{nullptr, time_kernel});
 
-            std::size_t flop = std::size_t(2) * N * K * Ho * Wo * C * Y * X;
+            std::size_t flop = 2_uz * N * K * Ho * Wo * C * Y * X;
 
             std::size_t num_btype =
                 sizeof(InDataType) * (N * C * Hi * Wi) + sizeof(WeiDataType) * (K * C * Y * X) +
@@ -249,22 +247,19 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
 
             if(do_verification)
             {
-                out_device_buf.FromDevice(out_n_k_ho_wo_device_result.mData.data());
+                out_device_buf.FromDevice(out_n_k_ho_wo_device_result.data());
 
-                ck::utils::check_err(out_n_k_ho_wo_device_result.mData,
-                                     out_n_k_ho_wo_host_result.mData);
+                ck::utils::check_err(out_n_k_ho_wo_device_result, out_n_k_ho_wo_host_result);
 
                 if(do_log)
                 {
-                    LogRangeAsType<float>(std::cout << "in : ", in_n_c_hi_wi.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(std::cout << "wei: ", wei_k_c_y_x.mData, ",")
+                    LogRangeAsType<float>(std::cout << "in : ", in_n_c_hi_wi, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "wei: ", wei_k_c_y_x, ",") << std::endl;
+                    LogRangeAsType<float>(
+                        std::cout << "out_host  : ", out_n_k_ho_wo_host_result, ",")
                         << std::endl;
                     LogRangeAsType<float>(
-                        std::cout << "out_host  : ", out_n_k_ho_wo_host_result.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(
-                        std::cout << "out_device: ", out_n_k_ho_wo_device_result.mData, ",")
+                        std::cout << "out_device: ", out_n_k_ho_wo_device_result, ",")
                         << std::endl;
                 }
             }

--- a/profiler/include/profile_conv_fwd_bias_relu_add_impl.hpp
+++ b/profiler/include/profile_conv_fwd_bias_relu_add_impl.hpp
@@ -93,7 +93,7 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
         f_host_tensor_descriptor(N, K, Ho, Wo, OutLayout{}));
 
     // bias: assume contiguous 1d vector
-    Tensor<OutDataType> bias_k(HostTensorDescriptor({K}));
+    Tensor<OutDataType> bias_k({K});
 
     // residual: assume same layout as output tensor
     Tensor<OutDataType> resi_n_k_ho_wo(f_host_tensor_descriptor(N, K, Ho, Wo, OutLayout{}));

--- a/profiler/include/profile_conv_fwd_bias_relu_impl.hpp
+++ b/profiler/include/profile_conv_fwd_bias_relu_impl.hpp
@@ -4,15 +4,16 @@
 #pragma once
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd_bias_activation.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace tensor_operation {
@@ -66,21 +67,21 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
     const ck::index_t Ho = output_spatial_lengths[0];
     const ck::index_t Wo = output_spatial_lengths[1];
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t N_, std::size_t C_, std::size_t H, std::size_t W, auto layout) {
-            if constexpr(is_same<decltype(layout), ck::tensor_layout::convolution::NCHW>::value ||
-                         is_same<decltype(layout), ck::tensor_layout::convolution::KCYX>::value ||
-                         is_same<decltype(layout), ck::tensor_layout::convolution::NKHW>::value)
+            if constexpr(is_same_v<decltype(layout), ck::tensor_layout::convolution::NCHW> ||
+                         is_same_v<decltype(layout), ck::tensor_layout::convolution::KCYX> ||
+                         is_same_v<decltype(layout), ck::tensor_layout::convolution::NKHW>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({N_, C_, H, W}),
-                                            std::vector<std::size_t>({C_ * H * W, H * W, W, 1}));
+                return HostTensorDescriptor({N_, C_, H, W}, {C_ * H * W, H * W, W, 1_uz});
             }
-            else if constexpr(is_same<decltype(layout), tensor_layout::convolution::NHWC>::value ||
-                              is_same<decltype(layout), tensor_layout::convolution::KYXC>::value ||
-                              is_same<decltype(layout), tensor_layout::convolution::NHWK>::value)
+            else if constexpr(is_same_v<decltype(layout), tensor_layout::convolution::NHWC> ||
+                              is_same_v<decltype(layout), tensor_layout::convolution::KYXC> ||
+                              is_same_v<decltype(layout), tensor_layout::convolution::NHWK>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({N_, C_, H, W}),
-                                            std::vector<std::size_t>({C_ * H * W, 1, W * C_, C_}));
+                return HostTensorDescriptor({N_, C_, H, W}, {C_ * H * W, 1_uz, W * C_, C_});
             }
         };
 
@@ -92,13 +93,12 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
         f_host_tensor_descriptor(N, K, Ho, Wo, OutLayout{}));
 
     // bias: assume contiguous 1d vector
-    Tensor<OutDataType> bias_k(
-        HostTensorDescriptor(std::vector<std::size_t>({static_cast<std::size_t>(K)})));
+    Tensor<OutDataType> bias_k(HostTensorDescriptor({K}));
 
-    std::cout << "in_n_c_hi_wi: " << in_n_c_hi_wi.mDesc << std::endl;
-    std::cout << "wei_k_c_y_x: " << wei_k_c_y_x.mDesc << std::endl;
-    std::cout << "out_n_k_ho_wo: " << out_n_k_ho_wo_host_result.mDesc << std::endl;
-    std::cout << "bias_k: " << bias_k.mDesc << std::endl;
+    std::cout << "in_n_c_hi_wi: " << in_n_c_hi_wi.GetDesc() << std::endl;
+    std::cout << "wei_k_c_y_x: " << wei_k_c_y_x.GetDesc() << std::endl;
+    std::cout << "out_n_k_ho_wo: " << out_n_k_ho_wo_host_result.GetDesc() << std::endl;
+    std::cout << "bias_k: " << bias_k.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -149,15 +149,14 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
         ref_invoker.Run(ref_argument);
     }
 
-    DeviceMem in_device_buf(sizeof(InDataType) * in_n_c_hi_wi.mDesc.GetElementSpaceSize());
-    DeviceMem wei_device_buf(sizeof(WeiDataType) * wei_k_c_y_x.mDesc.GetElementSpaceSize());
-    DeviceMem out_device_buf(sizeof(OutDataType) *
-                             out_n_k_ho_wo_device_result.mDesc.GetElementSpaceSize());
-    DeviceMem bias_device_buf(sizeof(OutDataType) * bias_k.mDesc.GetElementSpaceSize());
+    DeviceMem in_device_buf(in_n_c_hi_wi.GetMemorySize());
+    DeviceMem wei_device_buf(wei_k_c_y_x.GetMemorySize());
+    DeviceMem out_device_buf(out_n_k_ho_wo_device_result.GetMemorySize());
+    DeviceMem bias_device_buf(bias_k.GetMemorySize());
 
-    in_device_buf.ToDevice(in_n_c_hi_wi.mData.data());
-    wei_device_buf.ToDevice(wei_k_c_y_x.mData.data());
-    bias_device_buf.ToDevice(bias_k.mData.data());
+    in_device_buf.ToDevice(in_n_c_hi_wi.data());
+    wei_device_buf.ToDevice(wei_k_c_y_x.data());
+    bias_device_buf.ToDevice(bias_k.data());
 
     using DeviceConvFwdBiasReluPtr = ck::tensor_operation::device::
         DeviceConvFwdBiasActivationPtr<InElementOp, WeiElementOp, OutElementOp>;
@@ -186,24 +185,23 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
     // profile device Conv instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<const InDataType*>(in_device_buf.GetDeviceBuffer()),
-            static_cast<const WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-            static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
-            static_cast<const OutDataType*>(bias_device_buf.GetDeviceBuffer()),
-            N,
-            K,
-            C,
-            input_spatial_lengths,
-            filter_spatial_lengths,
-            output_spatial_lengths,
-            conv_filter_strides,
-            conv_filter_dilations,
-            input_left_pads,
-            input_right_pads,
-            in_element_op,
-            wei_element_op,
-            out_element_op);
+        auto argument_ptr = op_ptr->MakeArgumentPointer(in_device_buf.GetDeviceBuffer(),
+                                                        wei_device_buf.GetDeviceBuffer(),
+                                                        out_device_buf.GetDeviceBuffer(),
+                                                        bias_device_buf.GetDeviceBuffer(),
+                                                        N,
+                                                        K,
+                                                        C,
+                                                        input_spatial_lengths,
+                                                        filter_spatial_lengths,
+                                                        output_spatial_lengths,
+                                                        conv_filter_strides,
+                                                        conv_filter_dilations,
+                                                        input_left_pads,
+                                                        input_right_pads,
+                                                        in_element_op,
+                                                        wei_element_op,
+                                                        out_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 
@@ -214,7 +212,7 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
             float ave_time =
                 invoker_ptr->Run(argument_ptr.get(), StreamConfig{nullptr, time_kernel});
 
-            std::size_t flop = std::size_t(2) * N * K * Ho * Wo * C * Y * X;
+            std::size_t flop = 2_uz * N * K * Ho * Wo * C * Y * X;
 
             std::size_t num_btype =
                 sizeof(InDataType) * (N * C * Hi * Wi) + sizeof(WeiDataType) * (K * C * Y * X) +
@@ -237,22 +235,19 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
 
             if(do_verification)
             {
-                out_device_buf.FromDevice(out_n_k_ho_wo_device_result.mData.data());
+                out_device_buf.FromDevice(out_n_k_ho_wo_device_result.data());
 
-                ck::utils::check_err(out_n_k_ho_wo_device_result.mData,
-                                     out_n_k_ho_wo_host_result.mData);
+                ck::utils::check_err(out_n_k_ho_wo_device_result, out_n_k_ho_wo_host_result);
 
                 if(do_log)
                 {
-                    LogRangeAsType<float>(std::cout << "in : ", in_n_c_hi_wi.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(std::cout << "wei: ", wei_k_c_y_x.mData, ",")
+                    LogRangeAsType<float>(std::cout << "in : ", in_n_c_hi_wi, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "wei: ", wei_k_c_y_x, ",") << std::endl;
+                    LogRangeAsType<float>(
+                        std::cout << "out_host  : ", out_n_k_ho_wo_host_result, ",")
                         << std::endl;
                     LogRangeAsType<float>(
-                        std::cout << "out_host  : ", out_n_k_ho_wo_host_result.mData, ",")
-                        << std::endl;
-                    LogRangeAsType<float>(
-                        std::cout << "out_device: ", out_n_k_ho_wo_device_result.mData, ",")
+                        std::cout << "out_device: ", out_n_k_ho_wo_device_result, ",")
                         << std::endl;
                 }
             }

--- a/profiler/include/profile_conv_fwd_bias_relu_impl.hpp
+++ b/profiler/include/profile_conv_fwd_bias_relu_impl.hpp
@@ -93,7 +93,7 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
         f_host_tensor_descriptor(N, K, Ho, Wo, OutLayout{}));
 
     // bias: assume contiguous 1d vector
-    Tensor<OutDataType> bias_k(HostTensorDescriptor({K}));
+    Tensor<OutDataType> bias_k({K});
 
     std::cout << "in_n_c_hi_wi: " << in_n_c_hi_wi.GetDesc() << std::endl;
     std::cout << "wei_k_c_y_x: " << wei_k_c_y_x.GetDesc() << std::endl;

--- a/profiler/include/profile_gemm_add_add_fastgelu_impl.hpp
+++ b/profiler/include/profile_gemm_add_add_fastgelu_impl.hpp
@@ -123,7 +123,7 @@ bool profile_gemm_add_add_fastgelu_impl(int do_verification,
     // run reference
     if(do_verification)
     {
-        Tensor<AccDataType> c_m_n(HostTensorDescriptor({M, N}));
+        Tensor<AccDataType> c_m_n({M, N});
 
         using ReferenceGemmInstance = ck::tensor_operation::host::ReferenceGemm<ADataType,
                                                                                 BDataType,

--- a/profiler/include/profile_gemm_bias_add_reduce_impl.hpp
+++ b/profiler/include/profile_gemm_bias_add_reduce_impl.hpp
@@ -99,12 +99,12 @@ void profile_gemm_bias_add_reduce_impl(int do_verification,
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor2d(M, N, StrideC, CLayout{}));
     Tensor<BiasDataType> bias_n(f_host_tensor_descriptor1d(N, 1));
     Tensor<D0DataType> d0_m_n(f_host_tensor_descriptor2d(M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> reduce0_m_host_result(HostTensorDescriptor({M}));
-    Tensor<ReduceDataType> reduce1_m_host_result(HostTensorDescriptor({M}));
+    Tensor<ReduceDataType> reduce0_m_host_result({M});
+    Tensor<ReduceDataType> reduce1_m_host_result({M});
 
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor2d(M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> reduce0_m_device_result(HostTensorDescriptor({M}));
-    Tensor<ReduceDataType> reduce1_m_device_result(HostTensorDescriptor({M}));
+    Tensor<ReduceDataType> reduce0_m_device_result({M});
+    Tensor<ReduceDataType> reduce1_m_device_result({M});
 
     std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
     std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;

--- a/profiler/include/profile_gemm_bilinear_impl.hpp
+++ b/profiler/include/profile_gemm_bilinear_impl.hpp
@@ -118,7 +118,7 @@ bool profile_gemm_bilinear_impl(int do_verification,
     // run reference
     if(do_verification)
     {
-        Tensor<AccDataType> c_m_n(HostTensorDescriptor({M, N}));
+        Tensor<AccDataType> c_m_n({M, N});
 
         using ReferenceGemmInstance = ck::tensor_operation::host::ReferenceGemm<ADataType,
                                                                                 BDataType,

--- a/profiler/include/profile_gemm_bilinear_impl.hpp
+++ b/profiler/include/profile_gemm_bilinear_impl.hpp
@@ -6,17 +6,19 @@
 #include <iomanip>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_gemm_multiple_d.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/library/tensor_operation_instance/gpu/gemm_bilinear.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/array.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace profiler {
@@ -44,17 +46,17 @@ bool profile_gemm_bilinear_impl(int do_verification,
                                 float alpha,
                                 float beta)
 {
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-            if(is_same<decltype(layout), tensor_layout::gemm::RowMajor>::value)
+            if constexpr(is_same_v<decltype(layout), tensor_layout::gemm::RowMajor>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -64,10 +66,10 @@ bool profile_gemm_bilinear_impl(int do_verification,
     Tensor<EDataType> e_m_n_device_result(f_host_tensor_descriptor(M, N, StrideE, ELayout{}));
     Tensor<EDataType> e_m_n_host_result(f_host_tensor_descriptor(M, N, StrideE, ELayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "d_m_n: " << d_m_n.mDesc << std::endl;
-    std::cout << "e_m_n: " << e_m_n_device_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "d_m_n: " << d_m_n.GetDesc() << std::endl;
+    std::cout << "e_m_n: " << e_m_n_device_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -116,8 +118,7 @@ bool profile_gemm_bilinear_impl(int do_verification,
     // run reference
     if(do_verification)
     {
-        Tensor<AccDataType> c_m_n(HostTensorDescriptor(
-            std::vector<std::size_t>{static_cast<std::size_t>(M), static_cast<std::size_t>(N)}));
+        Tensor<AccDataType> c_m_n(HostTensorDescriptor({M, N}));
 
         using ReferenceGemmInstance = ck::tensor_operation::host::ReferenceGemm<ADataType,
                                                                                 BDataType,
@@ -144,14 +145,14 @@ bool profile_gemm_bilinear_impl(int do_verification,
         }
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem d_m_n_device_buf(sizeof(DDataType) * d_m_n.mDesc.GetElementSpaceSize());
-    DeviceMem e_device_buf(sizeof(EDataType) * e_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem d_m_n_device_buf(d_m_n.GetMemorySize());
+    DeviceMem e_device_buf(e_m_n_device_result.GetMemorySize());
 
-    a_device_buf.ToDevice(a_m_k.mData.data());
-    b_device_buf.ToDevice(b_k_n.mData.data());
-    d_m_n_device_buf.ToDevice(d_m_n.mData.data());
+    a_device_buf.ToDevice(a_m_k.data());
+    b_device_buf.ToDevice(b_k_n.data());
+    d_m_n_device_buf.ToDevice(d_m_n.data());
 
     std::string best_op_name;
     float best_ave_time   = 0;
@@ -163,21 +164,21 @@ bool profile_gemm_bilinear_impl(int do_verification,
     // profile device operation instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            a_device_buf.GetDeviceBuffer(),
-            b_device_buf.GetDeviceBuffer(),
-            std::array<const void*, 1>{d_m_n_device_buf.GetDeviceBuffer()},
-            e_device_buf.GetDeviceBuffer(),
-            M,
-            N,
-            K,
-            StrideA,
-            StrideB,
-            std::array<ck::index_t, 1>{StrideD},
-            StrideE,
-            a_element_op,
-            b_element_op,
-            cde_element_op);
+        auto argument_ptr =
+            op_ptr->MakeArgumentPointer(a_device_buf.GetDeviceBuffer(),
+                                        b_device_buf.GetDeviceBuffer(),
+                                        ck::utils::to_array({d_m_n_device_buf.GetDeviceBuffer()}),
+                                        e_device_buf.GetDeviceBuffer(),
+                                        M,
+                                        N,
+                                        K,
+                                        StrideA,
+                                        StrideB,
+                                        ck::utils::to_array({StrideD}),
+                                        StrideE,
+                                        a_element_op,
+                                        b_element_op,
+                                        cde_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 
@@ -191,7 +192,7 @@ bool profile_gemm_bilinear_impl(int do_verification,
             float ave_time =
                 invoker_ptr->Run(argument_ptr.get(), StreamConfig{nullptr, time_kernel});
 
-            std::size_t flop = std::size_t(2) * M * N * K;
+            std::size_t flop = 2_uz * M * N * K;
 
             std::size_t num_btype =
                 sizeof(ADataType) * M * K + sizeof(BDataType) * K * N + sizeof(EDataType) * M * N;
@@ -213,10 +214,9 @@ bool profile_gemm_bilinear_impl(int do_verification,
 
             if(do_verification)
             {
-                e_device_buf.FromDevice(e_m_n_device_result.mData.data());
+                e_device_buf.FromDevice(e_m_n_device_result.data());
 
-                pass = pass &&
-                       ck::utils::check_err(e_m_n_device_result.mData, e_m_n_host_result.mData);
+                pass = pass && ck::utils::check_err(e_m_n_device_result, e_m_n_host_result);
             }
         }
         else

--- a/profiler/include/profile_gemm_impl.hpp
+++ b/profiler/include/profile_gemm_impl.hpp
@@ -8,17 +8,18 @@
 #include <typeinfo>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_gemm.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/library/tensor_operation_instance/gpu/gemm.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace profiler {
@@ -43,17 +44,17 @@ int profile_gemm_impl(int do_verification,
 {
     bool pass = true;
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-            if(is_same<decltype(layout), tensor_layout::gemm::RowMajor>::value)
+            if constexpr(is_same_v<decltype(layout), tensor_layout::gemm::RowMajor>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -62,9 +63,9 @@ int profile_gemm_impl(int do_verification,
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "c_m_n: " << c_m_n_device_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "c_m_n: " << c_m_n_device_result.GetDesc() << std::endl;
 
     switch(init_method)
     {
@@ -86,12 +87,12 @@ int profile_gemm_impl(int do_verification,
     const auto b_element_op = BElementOp{};
     const auto c_element_op = CElementOp{};
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_device_buf(sizeof(CDataType) * c_m_n_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem c_device_buf(c_m_n_device_result.GetMemorySize());
 
-    a_device_buf.ToDevice(a_m_k.mData.data());
-    b_device_buf.ToDevice(b_k_n.mData.data());
+    a_device_buf.ToDevice(a_m_k.data());
+    b_device_buf.ToDevice(b_k_n.data());
 
     using DeviceOp = ck::tensor_operation::device::DeviceGemm<ALayout,
                                                               BLayout,
@@ -137,19 +138,18 @@ int profile_gemm_impl(int do_verification,
     // profile device op instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr =
-            op_ptr->MakeArgumentPointer(static_cast<ADataType*>(a_device_buf.GetDeviceBuffer()),
-                                        static_cast<BDataType*>(b_device_buf.GetDeviceBuffer()),
-                                        static_cast<CDataType*>(c_device_buf.GetDeviceBuffer()),
-                                        M,
-                                        N,
-                                        K,
-                                        StrideA,
-                                        StrideB,
-                                        StrideC,
-                                        a_element_op,
-                                        b_element_op,
-                                        c_element_op);
+        auto argument_ptr = op_ptr->MakeArgumentPointer(a_device_buf.GetDeviceBuffer(),
+                                                        b_device_buf.GetDeviceBuffer(),
+                                                        c_device_buf.GetDeviceBuffer(),
+                                                        M,
+                                                        N,
+                                                        K,
+                                                        StrideA,
+                                                        StrideB,
+                                                        StrideC,
+                                                        a_element_op,
+                                                        b_element_op,
+                                                        c_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 
@@ -163,7 +163,7 @@ int profile_gemm_impl(int do_verification,
             float avg_time =
                 invoker_ptr->Run(argument_ptr.get(), StreamConfig{nullptr, time_kernel});
 
-            std::size_t flop = std::size_t(2) * M * N * K;
+            std::size_t flop = 2_uz * M * N * K;
 
             std::size_t num_btype =
                 sizeof(ADataType) * M * K + sizeof(BDataType) * K * N + sizeof(CDataType) * M * N;
@@ -185,18 +185,17 @@ int profile_gemm_impl(int do_verification,
 
             if(do_verification)
             {
-                c_device_buf.FromDevice(c_m_n_device_result.mData.data());
+                c_device_buf.FromDevice(c_m_n_device_result.data());
 
-                pass =
-                    pass & ck::utils::check_err(c_m_n_device_result.mData, c_m_n_host_result.mData);
+                pass = pass & ck::utils::check_err(c_m_n_device_result, c_m_n_host_result);
 
                 if(do_log)
                 {
-                    LogRangeAsType<float>(std::cout << "a : ", a_m_k.mData, ",") << std::endl;
-                    LogRangeAsType<float>(std::cout << "b: ", b_k_n.mData, ",") << std::endl;
-                    LogRangeAsType<float>(std::cout << "c_host  : ", c_m_n_host_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "a : ", a_m_k, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "b: ", b_k_n, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "c_host  : ", c_m_n_host_result, ",")
                         << std::endl;
-                    LogRangeAsType<float>(std::cout << "c_device: ", c_m_n_device_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "c_device: ", c_m_n_device_result, ",")
                         << std::endl;
                 }
             }

--- a/profiler/include/profile_gemm_reduce_impl.hpp
+++ b/profiler/include/profile_gemm_reduce_impl.hpp
@@ -92,12 +92,12 @@ bool profile_gemm_reduce_impl(int do_verification,
     Tensor<BDataType> b_k_n(f_host_tensor_descriptor(K, N, StrideB, BLayout{}));
 
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> reduce0_m_host_result(HostTensorDescriptor({M}));
-    Tensor<ReduceDataType> reduce1_m_host_result(HostTensorDescriptor({M}));
+    Tensor<ReduceDataType> reduce0_m_host_result({M});
+    Tensor<ReduceDataType> reduce1_m_host_result({M});
 
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> reduce0_m_device_result(HostTensorDescriptor({M}));
-    Tensor<ReduceDataType> reduce1_m_device_result(HostTensorDescriptor({M}));
+    Tensor<ReduceDataType> reduce0_m_device_result({M});
+    Tensor<ReduceDataType> reduce1_m_device_result({M});
 
     std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
     std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;

--- a/profiler/include/profile_gemm_reduce_impl.hpp
+++ b/profiler/include/profile_gemm_reduce_impl.hpp
@@ -4,17 +4,18 @@
 #pragma once
 
 #include "ck/ck.hpp"
-#include "ck/utility/reduction_operator.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_gemm_reduce.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+#include "ck/utility/reduction_operator.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/literals.hpp"
 
 namespace ck {
 namespace tensor_operation {
@@ -73,17 +74,17 @@ bool profile_gemm_reduce_impl(int do_verification,
 {
     bool pass = true;
 
+    using namespace ck::literals;
+
     auto f_host_tensor_descriptor =
         [](std::size_t row, std::size_t col, std::size_t stride, auto layout) {
-            if(is_same<decltype(layout), tensor_layout::gemm::RowMajor>::value)
+            if constexpr(is_same_v<decltype(layout), tensor_layout::gemm::RowMajor>)
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({stride, 1}));
+                return HostTensorDescriptor({row, col}, {stride, 1_uz});
             }
             else
             {
-                return HostTensorDescriptor(std::vector<std::size_t>({row, col}),
-                                            std::vector<std::size_t>({1, stride}));
+                return HostTensorDescriptor({row, col}, {1_uz, stride});
             }
         };
 
@@ -91,22 +92,18 @@ bool profile_gemm_reduce_impl(int do_verification,
     Tensor<BDataType> b_k_n(f_host_tensor_descriptor(K, N, StrideB, BLayout{}));
 
     Tensor<CDataType> c_m_n_host_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> reduce0_m_host_result(
-        HostTensorDescriptor(std::vector<std::size_t>({static_cast<std::size_t>(M)})));
-    Tensor<ReduceDataType> reduce1_m_host_result(
-        HostTensorDescriptor(std::vector<std::size_t>({static_cast<std::size_t>(M)})));
+    Tensor<ReduceDataType> reduce0_m_host_result(HostTensorDescriptor({M}));
+    Tensor<ReduceDataType> reduce1_m_host_result(HostTensorDescriptor({M}));
 
     Tensor<CDataType> c_m_n_device_result(f_host_tensor_descriptor(M, N, StrideC, CLayout{}));
-    Tensor<ReduceDataType> reduce0_m_device_result(
-        HostTensorDescriptor(std::vector<std::size_t>({static_cast<std::size_t>(M)})));
-    Tensor<ReduceDataType> reduce1_m_device_result(
-        HostTensorDescriptor(std::vector<std::size_t>({static_cast<std::size_t>(M)})));
+    Tensor<ReduceDataType> reduce0_m_device_result(HostTensorDescriptor({M}));
+    Tensor<ReduceDataType> reduce1_m_device_result(HostTensorDescriptor({M}));
 
-    std::cout << "a_m_k: " << a_m_k.mDesc << std::endl;
-    std::cout << "b_k_n: " << b_k_n.mDesc << std::endl;
-    std::cout << "c_m_n: " << c_m_n_host_result.mDesc << std::endl;
-    std::cout << "reduce0_m: " << reduce0_m_host_result.mDesc << std::endl;
-    std::cout << "reduce1_m: " << reduce1_m_host_result.mDesc << std::endl;
+    std::cout << "a_m_k: " << a_m_k.GetDesc() << std::endl;
+    std::cout << "b_k_n: " << b_k_n.GetDesc() << std::endl;
+    std::cout << "c_m_n: " << c_m_n_host_result.GetDesc() << std::endl;
+    std::cout << "reduce0_m: " << reduce0_m_host_result.GetDesc() << std::endl;
+    std::cout << "reduce1_m: " << reduce1_m_host_result.GetDesc() << std::endl;
 
     std::size_t num_thread = 1;
     switch(init_method)
@@ -189,19 +186,17 @@ bool profile_gemm_reduce_impl(int do_verification,
         }
     }
 
-    DeviceMem a_device_buf(sizeof(ADataType) * a_m_k.mDesc.GetElementSpaceSize());
-    DeviceMem b_device_buf(sizeof(BDataType) * b_k_n.mDesc.GetElementSpaceSize());
-    DeviceMem c_device_buf(sizeof(CDataType) * c_m_n_device_result.mDesc.GetElementSpaceSize());
-    DeviceMem reduce0_device_buf(sizeof(ReduceDataType) *
-                                 reduce0_m_device_result.mDesc.GetElementSpaceSize());
-    DeviceMem reduce1_device_buf(sizeof(ReduceDataType) *
-                                 reduce1_m_device_result.mDesc.GetElementSpaceSize());
+    DeviceMem a_device_buf(a_m_k.GetMemorySize());
+    DeviceMem b_device_buf(b_k_n.GetMemorySize());
+    DeviceMem c_device_buf(c_m_n_device_result.GetMemorySize());
+    DeviceMem reduce0_device_buf(reduce0_m_device_result.GetMemorySize());
+    DeviceMem reduce1_device_buf(reduce1_m_device_result.GetMemorySize());
 
     std::array<void*, 2> p_reduces = {reduce0_device_buf.GetDeviceBuffer(),
                                       reduce1_device_buf.GetDeviceBuffer()};
 
-    a_device_buf.ToDevice(a_m_k.mData.data());
-    b_device_buf.ToDevice(b_k_n.mData.data());
+    a_device_buf.ToDevice(a_m_k.data());
+    b_device_buf.ToDevice(b_k_n.data());
 
     // add device GEMM instances
     std::vector<ck::tensor_operation::device::instance::DeviceGemmReduceNoOpPtr> gemm_ptrs;
@@ -287,7 +282,7 @@ bool profile_gemm_reduce_impl(int do_verification,
 
             std::string gemm_name = gemm_ptr->GetTypeString();
 
-            std::size_t flop = std::size_t(2) * M * N * K;
+            std::size_t flop = 2_uz * M * N * K;
 
             std::size_t num_btype = sizeof(ADataType) * M * K + sizeof(BDataType) * K * N +
                                     sizeof(CDataType) * M * N + sizeof(CDataType) * N;
@@ -309,33 +304,29 @@ bool profile_gemm_reduce_impl(int do_verification,
 
             if(do_verification)
             {
-                c_device_buf.FromDevice(c_m_n_device_result.mData.data());
-                reduce0_device_buf.FromDevice(reduce0_m_device_result.mData.data());
-                reduce1_device_buf.FromDevice(reduce1_m_device_result.mData.data());
+                c_device_buf.FromDevice(c_m_n_device_result.data());
+                reduce0_device_buf.FromDevice(reduce0_m_device_result.data());
+                reduce1_device_buf.FromDevice(reduce1_m_device_result.data());
 
-                ck::utils::check_err(c_m_n_device_result.mData, c_m_n_host_result.mData);
-                ck::utils::check_err(reduce0_m_device_result.mData, reduce0_m_host_result.mData);
-                ck::utils::check_err(reduce1_m_device_result.mData, reduce1_m_host_result.mData);
+                ck::utils::check_err(c_m_n_device_result, c_m_n_host_result);
+                ck::utils::check_err(reduce0_m_device_result, reduce0_m_host_result);
+                ck::utils::check_err(reduce1_m_device_result, reduce1_m_host_result);
 
                 if(do_log)
                 {
-                    LogRangeAsType<float>(std::cout << "a : ", a_m_k.mData, ",") << std::endl;
-                    LogRangeAsType<float>(std::cout << "b: ", b_k_n.mData, ",") << std::endl;
-                    LogRangeAsType<float>(std::cout << "c_host: ", c_m_n_host_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "a : ", a_m_k, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "b: ", b_k_n, ",") << std::endl;
+                    LogRangeAsType<float>(std::cout << "c_host: ", c_m_n_host_result, ",")
                         << std::endl;
-                    LogRangeAsType<float>(std::cout << "c_device: ", c_m_n_device_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "c_device: ", c_m_n_device_result, ",")
                         << std::endl;
-                    LogRangeAsType<float>(
-                        std::cout << "d0_host: ", reduce0_m_host_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "d0_host: ", reduce0_m_host_result, ",")
                         << std::endl;
-                    LogRangeAsType<float>(
-                        std::cout << "d0_device: ", reduce0_m_device_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "d0_device: ", reduce0_m_device_result, ",")
                         << std::endl;
-                    LogRangeAsType<float>(
-                        std::cout << "d1_host: ", reduce1_m_host_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "d1_host: ", reduce1_m_host_result, ",")
                         << std::endl;
-                    LogRangeAsType<float>(
-                        std::cout << "d1_device: ", reduce1_m_device_result.mData, ",")
+                    LogRangeAsType<float>(std::cout << "d1_device: ", reduce1_m_device_result, ",")
                         << std::endl;
                 }
             }

--- a/test/data_type/int4.cpp
+++ b/test/data_type/int4.cpp
@@ -98,8 +98,8 @@ TEST(Int4, CopyAsI8PositiveValue)
 
     d_src_i4.ToDevice(h_src_i4.data());
 
-    copy<<<1, 64>>>(reinterpret_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
-                    reinterpret_cast<std::int8_t*>(d_dst_i8.GetDeviceBuffer()),
+    copy<<<1, 64>>>(static_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
+                    static_cast<std::int8_t*>(d_dst_i8.GetDeviceBuffer()),
                     SIZE);
     hip_check_error(hipDeviceSynchronize());
     d_dst_i8.FromDevice(h_dst_i8.data());
@@ -125,8 +125,8 @@ TEST(Int4, DISABLED_CopyAsI8NegativeValue)
 
     d_src_i4.ToDevice(h_src_i4.data());
 
-    copy<<<1, 64>>>(reinterpret_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
-                    reinterpret_cast<std::int8_t*>(d_dst_i8.GetDeviceBuffer()),
+    copy<<<1, 64>>>(static_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
+                    static_cast<std::int8_t*>(d_dst_i8.GetDeviceBuffer()),
                     SIZE);
     hip_check_error(hipDeviceSynchronize());
     d_dst_i8.FromDevice(h_dst_i8.data());
@@ -152,8 +152,8 @@ TEST(Int4, CopyAsI8NegativeValueStaticCast)
 
     d_src_i4.ToDevice(h_src_i4.data());
 
-    copy_with_static_cast<<<1, 64>>>(reinterpret_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
-                                     reinterpret_cast<std::int8_t*>(d_dst_i8.GetDeviceBuffer()),
+    copy_with_static_cast<<<1, 64>>>(static_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
+                                     static_cast<std::int8_t*>(d_dst_i8.GetDeviceBuffer()),
                                      SIZE);
     hip_check_error(hipDeviceSynchronize());
     d_dst_i8.FromDevice(h_dst_i8.data());

--- a/test/reference_conv_fwd/reference_conv_fwd.cpp
+++ b/test/reference_conv_fwd/reference_conv_fwd.cpp
@@ -6,18 +6,19 @@
 #include <numeric>
 #include <type_traits>
 #include <vector>
+
 #include <gtest/gtest.h>
 
 #include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
 #include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
+#include "ck/library/utility/convolution_parameter.hpp"
 #include "ck/library/utility/fill.hpp"
 #include "ck/library/utility/host_tensor.hpp"
-#include "ck/library/utility/convolution_parameter.hpp"
-#include "ck/library/utility/convolution_host_tensor_descriptor_helper.hpp"
-#include "ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp"
 
 namespace {
 
@@ -121,8 +122,8 @@ TEST(ReferenceConvolutionFWD, Conv2DGNHWC)
                                 490.5,
                                 508.5};
     EXPECT_TRUE(ck::utils::check_err(
-        out_tensor.mDesc.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
-    EXPECT_TRUE(ck::utils::check_err(out_tensor.mData, ref_data, "Error: incorrect results!"));
+        out_tensor.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
+    EXPECT_TRUE(ck::utils::check_err(out_tensor, ref_data, "Error: incorrect results!"));
 }
 
 TEST(ReferenceConvolutionFWD, Conv2DGNHWCStridesDilationsPadding)
@@ -140,7 +141,7 @@ TEST(ReferenceConvolutionFWD, Conv2DGNHWCStridesDilationsPadding)
                                           std::vector<ck::index_t>{1, 1});
 
     auto out_tensor                   = run_reference_convolution_forward<2>(conv_param);
-    std::vector<std::size_t> ref_dims = std::vector<std::size_t>{1, 5, 5, 2};
+    std::vector<std::size_t> ref_dims{1, 5, 5, 2};
     std::vector<float> ref_data{
         210.,  210.,  327.,   327.,   351.,   351.,   375.,   375.,   399.,   399.,
         459.,  459.,  706.5,  706.5,  742.5,  742.5,  778.5,  778.5,  814.5,  814.5,
@@ -148,8 +149,8 @@ TEST(ReferenceConvolutionFWD, Conv2DGNHWCStridesDilationsPadding)
         1035., 1035., 1570.5, 1570.5, 1606.5, 1606.5, 1642.5, 1642.5, 1678.5, 1678.5,
         1323., 1323., 2002.5, 2002.5, 2038.5, 2038.5, 2074.5, 2074.5, 2110.5, 2110.5};
     EXPECT_TRUE(ck::utils::check_err(
-        out_tensor.mDesc.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
-    EXPECT_TRUE(ck::utils::check_err(out_tensor.mData, ref_data, "Error: incorrect results!"));
+        out_tensor.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
+    EXPECT_TRUE(ck::utils::check_err(out_tensor, ref_data, "Error: incorrect results!"));
 }
 
 TEST(ReferenceConvolutionFWD, Conv1DGNWC)
@@ -177,8 +178,8 @@ TEST(ReferenceConvolutionFWD, Conv1DGNWC)
     std::vector<std::size_t> ref_dims{1, 1, 4, 1};
     std::vector<float> ref_data{7.5, 13.5, 19.5, 25.5};
     EXPECT_TRUE(ck::utils::check_err(
-        out_tensor.mDesc.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
-    EXPECT_TRUE(ck::utils::check_err(out_tensor.mData, ref_data, "Error: incorrect results!"));
+        out_tensor.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
+    EXPECT_TRUE(ck::utils::check_err(out_tensor, ref_data, "Error: incorrect results!"));
 }
 
 TEST(ReferenceConvolutionFWD, Conv1DGNWCStridesDilationsPadding)
@@ -206,8 +207,8 @@ TEST(ReferenceConvolutionFWD, Conv1DGNWCStridesDilationsPadding)
     std::vector<std::size_t> ref_dims{1, 1, 5, 2};
     std::vector<float> ref_data{9., 9., 19.5, 19.5, 31.5, 31.5, 43.5, 43.5, 55.5, 55.5};
     EXPECT_TRUE(ck::utils::check_err(
-        out_tensor.mDesc.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
-    EXPECT_TRUE(ck::utils::check_err(out_tensor.mData, ref_data, "Error: incorrect results!"));
+        out_tensor.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
+    EXPECT_TRUE(ck::utils::check_err(out_tensor, ref_data, "Error: incorrect results!"));
 }
 
 TEST(ReferenceConvolutionFWD, Conv1DGNWCSameOutputSize)
@@ -300,8 +301,8 @@ TEST(ReferenceConvolutionFWD, Conv1DGNWCSameOutputSize)
         49.4,      49.4,      49.4,      49.4,      49.4,      49.4,      49.4,      49.4,
         49.4,      49.4,      49.4,      49.4,      49.4,      49.4,      49.4,      49.4};
     EXPECT_TRUE(ck::utils::check_err(
-        out_tensor2.mDesc.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
-    EXPECT_TRUE(ck::utils::check_err(out_tensor2.mData, ref_data, "Error: incorrect results!"));
+        out_tensor2.GetLengths(), ref_dims, "Error: wrong output tensor dimensions!"));
+    EXPECT_TRUE(ck::utils::check_err(out_tensor2, ref_data, "Error: incorrect results!"));
 }
 #endif
 
@@ -337,11 +338,9 @@ TEST(ReferenceConvolutionFWD, Conv3DGNCDHW)
         634.5,     637.2,     639.9,     642.60004, 650.7,     653.4,     656.10004, 658.8,
         699.3,     702.,      704.7,     707.4,     715.5,     718.2,     720.9,     723.60004,
         731.7,     734.4001,  737.10004, 739.8,     747.9001,  750.60004, 753.3,     756.};
-    EXPECT_TRUE(ck::utils::check_err(out_tensor.mDesc.GetLengths(),
-                                     ref_dims,
-                                     "Error [case 1]: wrong output tensor dimensions!"));
-    EXPECT_TRUE(
-        ck::utils::check_err(out_tensor.mData, ref_data, "Error [case 1]: incorrect results!"));
+    EXPECT_TRUE(ck::utils::check_err(
+        out_tensor.GetLengths(), ref_dims, "Error [case 1]: wrong output tensor dimensions!"));
+    EXPECT_TRUE(ck::utils::check_err(out_tensor, ref_data, "Error [case 1]: incorrect results!"));
 }
 
 TEST(ReferenceConvolutionFWD, Conv3DGNCDHWStridesDilations)
@@ -384,9 +383,8 @@ TEST(ReferenceConvolutionFWD, Conv3DGNCDHWStridesDilations)
         5283.9004, 5292.,     5300.0996, 5308.2,    5381.0996, 5389.2,    5397.3,    5405.4004,
         6255.9004, 6264.0005, 6272.1,    6280.2,    6353.1,    6361.2,    6369.301,  6377.4,
         6450.301,  6458.4,    6466.5,    6474.6,    6547.5,    6555.6,    6563.699,  6571.801};
-    EXPECT_TRUE(ck::utils::check_err(out_tensor.mDesc.GetLengths(),
-                                     ref_dims,
-                                     "Error [case 2]: wrong output tensor dimensions!"));
     EXPECT_TRUE(ck::utils::check_err(
-        out_tensor.mData, ref_data, "Error [case 2]: incorrect results!", 1e-4f, 1e-6f));
+        out_tensor.GetLengths(), ref_dims, "Error [case 2]: wrong output tensor dimensions!"));
+    EXPECT_TRUE(ck::utils::check_err(
+        out_tensor, ref_data, "Error [case 2]: incorrect results!", 1e-4f, 1e-6f));
 }


### PR DESCRIPTION
Changes in this PR:

- Add `ck::utils::to_array()` to convert C-array to `std::array`; range to `std::array`
- Add `ck::utils::empty_array()` to convert to `std::array<T, 0>` (`T` is arbitrary type)
- Add `ck::utils::mutable_buffer` (borrowed from _Boost.Asio_) which can be implicitly converted to raw pointers (do size-checking while converting). Let `DeviceMem::GetDeviceBuffer()` return `ck::utils::mutable_buffer` instead of `void* `
- Add `Tensor<>::GetMemorySize()` to avoid duplicated byte-size calculating logics
- Add `ck::accumulate_n()` algorithm to avoid duplicated iterator calculating logics
- Add `ck::ranges::to()` to convert between range types (_C++23_)
- Add range & iterator type traits (_C++20_)
- Rangify `std::copy()`, `std::fill()`, `std::transform()` (_C++20_)
- Rangify `ck::utils::check_err()`, allow `ck::utils::check_err()` compares between different ranges
- Rangify call operators of `ck::utils::FillUniformDistribution<>` and `ck::utils::FillUniformDistributionIntegerValue<>`
- Hide `Tensor<>::mDesc` & `Tensor<>::mData` data members to avoid class invariant violation
- Sort include directives (in lexicographical order)