### PR TITLE
Updated the supported components

### DIFF
--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-set(_composable_kernel_supported_components device_operations host_tensor)
+set(_composable_kernel_supported_components device_operations utility)
 
 foreach(_comp ${composable_kernel_FIND_COMPONENTS})
 	if(NOT _comp IN_LIST _composable_kernel_supported_components)


### PR DESCRIPTION
The supported components name should match the name [here](https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/01876afafe1c09028dc4d513b5d040cec798fae6/library/src/utility/CMakeLists.txt#L23).

This PR blocks https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1673