### PR TITLE
Introduce ck::auto_cast()

### DIFF
--- a/example/01_gemm/common.hpp
+++ b/example/01_gemm/common.hpp
@@ -14,6 +14,7 @@
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 #include "ck/utility/data_type.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/fill.hpp"

--- a/example/01_gemm/gemm_xdl_skip_b_lds_fp16.cpp
+++ b/example/01_gemm/gemm_xdl_skip_b_lds_fp16.cpp
@@ -187,9 +187,9 @@ int main(int argc, char* argv[])
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-                                      static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-                                      static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_m_n_device_buf.GetDeviceBuffer()),
                                       M,
                                       N,
                                       K,

--- a/example/01_gemm/run_gemm_example.inc
+++ b/example/01_gemm/run_gemm_example.inc
@@ -76,25 +76,18 @@ bool run_gemm(const ProblemSize& problem_size, const ExecutionConfig& config)
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<KernelBDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<KernelCDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
-#endif
-        M,
-        N,
-        K,
-        StrideA,
-        StrideB,
-        StrideC,
-        a_element_op,
-        b_element_op,
-        c_element_op);
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_m_n_device_buf.GetDeviceBuffer()),
+                                      M,
+                                      N,
+                                      K,
+                                      StrideA,
+                                      StrideB,
+                                      StrideC,
+                                      a_element_op,
+                                      b_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {

--- a/example/13_pool2d_fwd/pool2d_fwd_common.hpp
+++ b/example/13_pool2d_fwd/pool2d_fwd_common.hpp
@@ -12,6 +12,7 @@
 #include "ck/tensor_operation/gpu/device/device_pool2d_fwd_nhwc_nhwc.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -212,20 +213,20 @@ bool pool_test(bool do_verification,
 
     in_device_buf.ToDevice(in_n_c_hi_wi.mData.data());
 
-    auto pool         = DevicePoolFwdInstance{};
-    auto invoker_ptr  = pool.MakeInvokerPointer();
-    auto argument_ptr = pool.MakeArgumentPointer(
-        static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-        static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
-        static_cast<IndexDataType*>(out_indices_device_buf.GetDeviceBuffer()),
-        N,
-        C,
-        std::array<ck::index_t, 2>{{Hi, Wi}},
-        std::array<ck::index_t, 2>{{Y, X}},
-        std::array<ck::index_t, 2>{{Ho, Wo}},
-        window_strides,
-        input_left_pads,
-        input_right_pads);
+    auto pool        = DevicePoolFwdInstance{};
+    auto invoker_ptr = pool.MakeInvokerPointer();
+    auto argument_ptr =
+        pool.MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                 ck::auto_cast(out_device_buf.GetDeviceBuffer()),
+                                 ck::auto_cast(out_indices_device_buf.GetDeviceBuffer()),
+                                 N,
+                                 C,
+                                 std::array<ck::index_t, 2>{{Hi, Wi}},
+                                 std::array<ck::index_t, 2>{{Y, X}},
+                                 std::array<ck::index_t, 2>{{Ho, Wo}},
+                                 window_strides,
+                                 input_left_pads,
+                                 input_right_pads);
 
     if(!pool.IsSupportedArgument(argument_ptr.get()))
     {

--- a/example/14_gemm_xdl_requant_relu_requant/gemm_xdl_requant_relu_requant_int8.cpp
+++ b/example/14_gemm_xdl_requant_relu_requant/gemm_xdl_requant_relu_requant_int8.cpp
@@ -12,6 +12,7 @@
 #include "ck/tensor_operation/gpu/device/device_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
@@ -204,9 +205,9 @@ int main(int argc, char* argv[])
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-                                      static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-                                      static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_m_n_device_buf.GetDeviceBuffer()),
                                       M,
                                       N,
                                       K,

--- a/example/17_convnd_bwd_data/convnd_bwd_data_common.hpp
+++ b/example/17_convnd_bwd_data/convnd_bwd_data_common.hpp
@@ -10,6 +10,7 @@
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -79,9 +80,9 @@ int run_conv_bwd_data(bool do_verification,
     // do GEMM
     auto conv     = DeviceConvNdBwdDataInstance{};
     auto invoker  = conv.MakeInvoker();
-    auto argument = conv.MakeArgument(static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-                                      static_cast<WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-                                      static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
+    auto argument = conv.MakeArgument(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(out_device_buf.GetDeviceBuffer()),
                                       conv_param.N_,
                                       conv_param.K_,
                                       conv_param.C_,

--- a/example/20_convnd_bwd_weight/convnd_bwd_weight_common.hpp
+++ b/example/20_convnd_bwd_weight/convnd_bwd_weight_common.hpp
@@ -10,6 +10,7 @@
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -80,9 +81,9 @@ int run_conv_bwd_weight(bool do_verification,
     // do GEMM
     auto conv     = DeviceConvBwdWeightInstance{};
     auto invoker  = conv.MakeInvoker();
-    auto argument = conv.MakeArgument(static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-                                      static_cast<WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-                                      static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
+    auto argument = conv.MakeArgument(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(out_device_buf.GetDeviceBuffer()),
                                       conv_param.N_,
                                       conv_param.K_,
                                       conv_param.C_,

--- a/example/21_gemm_layernorm/gemm_xdl_layernorm_single_kernel_fp16.cpp
+++ b/example/21_gemm_layernorm/gemm_xdl_layernorm_single_kernel_fp16.cpp
@@ -6,6 +6,7 @@
 #include <initializer_list>
 
 #include "ck/ck.hpp"
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -208,13 +209,13 @@ int main(int argc, char* argv[])
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(static_cast<ADataType*>(a_device_buf.GetDeviceBuffer()),
-                                      static_cast<BDataType*>(b_device_buf.GetDeviceBuffer()),
-                                      static_cast<CDataType*>(c_device_buf.GetDeviceBuffer()),
-                                      static_cast<C0DataType*>(c0_add_buf.GetDeviceBuffer()),
-                                      static_cast<C0DataType*>(c0_bias_buf.GetDeviceBuffer()),
-                                      static_cast<C0DataType*>(c0_gamma_buf.GetDeviceBuffer()),
-                                      static_cast<C0DataType*>(c0_beta_buf.GetDeviceBuffer()),
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c0_add_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c0_bias_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c0_gamma_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c0_beta_buf.GetDeviceBuffer()),
                                       M,
                                       N,
                                       K,

--- a/example/22_cgemm/cgemm_xdl_common.hpp
+++ b/example/22_cgemm/cgemm_xdl_common.hpp
@@ -7,6 +7,7 @@
 
 #include "ck/ck.hpp"
 #include "ck/stream_config.hpp"
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -149,24 +150,23 @@ bool run_cgemm_xdl(ck::index_t M,
     auto c_element_op = CElementwiseOperation{};
 
     // do GEMM
-    auto invoker = cgemm.MakeInvoker();
-    auto argument =
-        cgemm.MakeArgument(static_cast<KernelADataType*>(a_m_k_real_device_buf.GetDeviceBuffer()),
-                           static_cast<KernelADataType*>(a_m_k_imag_device_buf.GetDeviceBuffer()),
-                           static_cast<KernelBDataType*>(b_k_n_real_device_buf.GetDeviceBuffer()),
-                           static_cast<KernelBDataType*>(b_k_n_imag_device_buf.GetDeviceBuffer()),
-                           static_cast<KernelCDataType*>(c_m_n_real_device_buf.GetDeviceBuffer()),
-                           static_cast<KernelCDataType*>(c_m_n_imag_device_buf.GetDeviceBuffer()),
-                           static_cast<KernelCDataType*>(workspace_device_buf.GetDeviceBuffer()),
-                           M,
-                           N,
-                           K,
-                           StrideA,
-                           StrideB,
-                           StrideC,
-                           a_element_op,
-                           b_element_op,
-                           c_element_op);
+    auto invoker  = cgemm.MakeInvoker();
+    auto argument = cgemm.MakeArgument(ck::auto_cast(a_m_k_real_device_buf.GetDeviceBuffer()),
+                                       ck::auto_cast(a_m_k_imag_device_buf.GetDeviceBuffer()),
+                                       ck::auto_cast(b_k_n_real_device_buf.GetDeviceBuffer()),
+                                       ck::auto_cast(b_k_n_imag_device_buf.GetDeviceBuffer()),
+                                       ck::auto_cast(c_m_n_real_device_buf.GetDeviceBuffer()),
+                                       ck::auto_cast(c_m_n_imag_device_buf.GetDeviceBuffer()),
+                                       ck::auto_cast(workspace_device_buf.GetDeviceBuffer()),
+                                       M,
+                                       N,
+                                       K,
+                                       StrideA,
+                                       StrideB,
+                                       StrideC,
+                                       a_element_op,
+                                       b_element_op,
+                                       c_element_op);
 
     if(!cgemm.IsSupportedArgument(argument))
     {

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_bf16.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_bf16.cpp
@@ -19,6 +19,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp16.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp16.cpp
@@ -19,6 +19,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp32.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_fp32.cpp
@@ -19,6 +19,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int4.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int4.cpp
@@ -23,6 +23,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int8.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int8.cpp
@@ -19,6 +19,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/31_batched_gemm_gemm/run_batched_gemm_gemm_example.inc
+++ b/example/31_batched_gemm_gemm/run_batched_gemm_gemm_example.inc
@@ -189,36 +189,28 @@ bool run_batched_gemm_gemm_example(int argc, char* argv[])
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<KernelB0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<KernelB1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-        static_cast<KernelCDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-        static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-        static_cast<CDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-#endif
-        M,
-        N,
-        K,
-        O,
-        BatchCount,
-        StrideA,
-        StrideB0,
-        StrideB1,
-        StrideC,
-        BatchStrideA,
-        BatchStrideB0,
-        BatchStrideB1,
-        BatchStrideC,
-        a_element_op,
-        b0_element_op,
-        acc0_element_op,
-        b1_element_op,
-        c_element_op);
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_g_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_g_m_o_device_buf.GetDeviceBuffer()),
+                                      M,
+                                      N,
+                                      K,
+                                      O,
+                                      BatchCount,
+                                      StrideA,
+                                      StrideB0,
+                                      StrideB1,
+                                      StrideC,
+                                      BatchStrideA,
+                                      BatchStrideB0,
+                                      BatchStrideB1,
+                                      BatchStrideC,
+                                      a_element_op,
+                                      b0_element_op,
+                                      acc0_element_op,
+                                      b1_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {

--- a/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_lower_triangle_scale_softmax_gemm_permute_xdl_fp16.cpp
+++ b/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_lower_triangle_scale_softmax_gemm_permute_xdl_fp16.cpp
@@ -20,6 +20,7 @@ Gemm + Softmax + Gemm fused operation. Computes C_g_m_o = Softmax(A_g_m_k * B0_g
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_softmax_gemm_permute_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -302,31 +303,30 @@ int main(int argc, char* argv[])
     auto c_element_op    = CElementOp{};
 
     // do GEMM
-    auto gemm    = DeviceGemmInstance{};
-    auto invoker = gemm.MakeInvoker();
-    auto argument =
-        gemm.MakeArgument(static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-                          static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-                          static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-                          static_cast<CDataType*>(c_gs_ms_os_device_buf.GetDeviceBuffer()),
-                          M,
-                          N,
-                          K,
-                          O,
-                          BatchCount,
-                          c_gs_ms_os_lengths,
-                          c_gs_ms_os_strides,
-                          StrideA,
-                          StrideB0,
-                          StrideB1,
-                          BatchStrideA,
-                          BatchStrideB0,
-                          BatchStrideB1,
-                          a_element_op,
-                          b0_element_op,
-                          acc0_element_op,
-                          b1_element_op,
-                          c_element_op);
+    auto gemm     = DeviceGemmInstance{};
+    auto invoker  = gemm.MakeInvoker();
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_g_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_gs_ms_os_device_buf.GetDeviceBuffer()),
+                                      M,
+                                      N,
+                                      K,
+                                      O,
+                                      BatchCount,
+                                      c_gs_ms_os_lengths,
+                                      c_gs_ms_os_strides,
+                                      StrideA,
+                                      StrideB0,
+                                      StrideB1,
+                                      BatchStrideA,
+                                      BatchStrideB0,
+                                      BatchStrideB1,
+                                      a_element_op,
+                                      b0_element_op,
+                                      acc0_element_op,
+                                      b1_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {

--- a/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_scale_softmax_gemm_permute_xdl_fp16.cpp
+++ b/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_scale_softmax_gemm_permute_xdl_fp16.cpp
@@ -20,6 +20,7 @@ Gemm + Softmax + Gemm fused operation. Computes C_g_m_o = Softmax(A_g_m_k * B0_g
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_softmax_gemm_permute_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -302,31 +303,30 @@ int main(int argc, char* argv[])
     auto c_element_op    = CElementOp{};
 
     // do GEMM
-    auto gemm    = DeviceGemmInstance{};
-    auto invoker = gemm.MakeInvoker();
-    auto argument =
-        gemm.MakeArgument(static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-                          static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-                          static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-                          static_cast<CDataType*>(c_gs_ms_os_device_buf.GetDeviceBuffer()),
-                          M,
-                          N,
-                          K,
-                          O,
-                          BatchCount,
-                          c_gs_ms_os_lengths,
-                          c_gs_ms_os_strides,
-                          StrideA,
-                          StrideB0,
-                          StrideB1,
-                          BatchStrideA,
-                          BatchStrideB0,
-                          BatchStrideB1,
-                          a_element_op,
-                          b0_element_op,
-                          acc0_element_op,
-                          b1_element_op,
-                          c_element_op);
+    auto gemm     = DeviceGemmInstance{};
+    auto invoker  = gemm.MakeInvoker();
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_g_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_gs_ms_os_device_buf.GetDeviceBuffer()),
+                                      M,
+                                      N,
+                                      K,
+                                      O,
+                                      BatchCount,
+                                      c_gs_ms_os_lengths,
+                                      c_gs_ms_os_strides,
+                                      StrideA,
+                                      StrideB0,
+                                      StrideB1,
+                                      BatchStrideA,
+                                      BatchStrideB0,
+                                      BatchStrideB1,
+                                      a_element_op,
+                                      b0_element_op,
+                                      acc0_element_op,
+                                      b1_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {

--- a/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_scale_softmax_gemm_xdl_fp16.cpp
+++ b/example/32_batched_gemm_scale_softmax_gemm/batched_gemm_scale_softmax_gemm_xdl_fp16.cpp
@@ -19,6 +19,7 @@ Gemm + Softmax + Gemm fused operation. Computes C_g_m_o = Softmax(A_g_m_k * B0_g
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_softmax_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -315,31 +316,30 @@ int main(int argc, char* argv[])
     auto c_element_op    = CElementOp{};
 
     // do GEMM
-    auto gemm    = DeviceGemmInstance{};
-    auto invoker = gemm.MakeInvoker();
-    auto argument =
-        gemm.MakeArgument(static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-                          static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-                          static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-                          static_cast<CDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-                          M,
-                          N,
-                          K,
-                          O,
-                          BatchCount,
-                          StrideA,
-                          StrideB0,
-                          StrideB1,
-                          StrideC,
-                          BatchStrideA,
-                          BatchStrideB0,
-                          BatchStrideB1,
-                          BatchStrideC,
-                          a_element_op,
-                          b0_element_op,
-                          acc0_element_op,
-                          b1_element_op,
-                          c_element_op);
+    auto gemm     = DeviceGemmInstance{};
+    auto invoker  = gemm.MakeInvoker();
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_g_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_g_m_o_device_buf.GetDeviceBuffer()),
+                                      M,
+                                      N,
+                                      K,
+                                      O,
+                                      BatchCount,
+                                      StrideA,
+                                      StrideB0,
+                                      StrideB1,
+                                      StrideC,
+                                      BatchStrideA,
+                                      BatchStrideB0,
+                                      BatchStrideB1,
+                                      BatchStrideC,
+                                      a_element_op,
+                                      b0_element_op,
+                                      acc0_element_op,
+                                      b1_element_op,
+                                      c_element_op);
 
     if(!gemm.IsSupportedArgument(argument))
     {

--- a/example/35_splitK_gemm/run_splitK_gemm_example.inc
+++ b/example/35_splitK_gemm/run_splitK_gemm_example.inc
@@ -93,25 +93,19 @@ bool run_splitK_gemm(const ProblemSize& problem_size, const ExecutionConfig& con
     // do GEMM
     auto gemm     = DeviceGemmInstance{};
     auto invoker  = gemm.MakeInvoker();
-    auto argument = gemm.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<KernelBDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-        static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-#endif
-        static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
-        M,
-        N,
-        K,
-        StrideA,
-        StrideB,
-        StrideC,
-        a_element_op,
-        b_element_op,
-        c_element_op,
-        KBatch);
+    auto argument = gemm.MakeArgument(ck::auto_cast(a_m_k_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(b_k_n_device_buf.GetDeviceBuffer()),
+                                      ck::auto_cast(c_m_n_device_buf.GetDeviceBuffer()),
+                                      M,
+                                      N,
+                                      K,
+                                      StrideA,
+                                      StrideB,
+                                      StrideC,
+                                      a_element_op,
+                                      b_element_op,
+                                      c_element_op,
+                                      KBatch);
 
     if(!gemm.IsSupportedArgument(argument))
     {

--- a/example/35_splitK_gemm/splitK_gemm_xdl_bfp16.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_bfp16.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/35_splitK_gemm/splitK_gemm_xdl_fp16.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_fp16.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/35_splitK_gemm/splitK_gemm_xdl_fp32.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_fp32.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/35_splitK_gemm/splitK_gemm_xdl_int4.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_int4.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/35_splitK_gemm/splitK_gemm_xdl_int8.cpp
+++ b/example/35_splitK_gemm/splitK_gemm_xdl_int8.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_gemm_xdl_splitk_c_shuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/37_batched_gemm_add_add_relu_gemm_add/batched_gemm_add_add_relu_gemm_add_xdl_fp16.cpp
+++ b/example/37_batched_gemm_add_add_relu_gemm_add/batched_gemm_add_add_relu_gemm_add_xdl_fp16.cpp
@@ -15,6 +15,7 @@ Computes C_m_o = Relu(A0[m, k] * B0[n, k] + D00[m, n] + D01[mn]) * B1[n, o] + D1
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_multiple_d_gemm_multiple_d_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/binary_element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -407,13 +408,13 @@ int main(int argc, char* argv[])
     auto gemm    = DeviceGemmInstance{};
     auto invoker = gemm.MakeInvoker();
     auto argument =
-        gemm.MakeArgument(static_cast<A0DataType*>(a0_g_m_k_device_buf.GetDeviceBuffer()),
-                          static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
+        gemm.MakeArgument(ck::auto_cast(a0_g_m_k_device_buf.GetDeviceBuffer()),
+                          ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
                           std::array<const void*, 2>{d00_g_m_n_device_buf.GetDeviceBuffer(),
                                                      d01_g_m_n_device_buf.GetDeviceBuffer()},
-                          static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                          ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
                           std::array<const void*, 1>{d1_g_m_o_device_buf.GetDeviceBuffer()},
-                          static_cast<E1DataType*>(e1_g_m_o_device_buf.GetDeviceBuffer()),
+                          ck::auto_cast(e1_g_m_o_device_buf.GetDeviceBuffer()),
                           M,
                           N,
                           K,

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_bf16.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_bf16.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp16.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp16.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp32.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_fp32.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int4.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int4.cpp
@@ -15,6 +15,7 @@
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int8.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int8.cpp
@@ -11,6 +11,7 @@
 #include "ck/tensor_operation/gpu/device/device_batched_gemm_gemm_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/example/41_grouped_conv_conv_fwd/run_grouped_conv_conv_fwd_example.inc
+++ b/example/41_grouped_conv_conv_fwd/run_grouped_conv_conv_fwd_example.inc
@@ -149,36 +149,28 @@ bool run_grouped_conv_conv_fwd(bool do_verification,
 
     auto device_op = DeviceOpInstance{};
     auto invoker   = device_op.MakeInvoker();
-    auto argument  = device_op.MakeArgument(
-#ifdef BUILD_INT4_EXAMPLE
-        static_cast<KernelIn0DataType*>(in0_device_buf.GetDeviceBuffer()),
-        static_cast<KernelWei0DataType*>(wei0_device_buf.GetDeviceBuffer()),
-        static_cast<KernelWei1DataType*>(wei1_device_buf.GetDeviceBuffer()),
-        static_cast<KernelOut1DataType*>(out1_device_buf.GetDeviceBuffer()),
-#else
-        static_cast<In0DataType*>(in0_device_buf.GetDeviceBuffer()),
-        static_cast<Wei0DataType*>(wei0_device_buf.GetDeviceBuffer()),
-        static_cast<Wei1DataType*>(wei1_device_buf.GetDeviceBuffer()),
-        static_cast<Out1DataType*>(out1_device_buf.GetDeviceBuffer()),
-#endif
-        gemm0_m_length,
-        gemm0_n_length,
-        gemm0_k_length,
-        gemm1_n_length,
-        gemm_batch,
-        a0_stride,
-        b0_stride,
-        b1_stride,
-        e1_stride,
-        a0_batch_stride,
-        b0_batch_stride,
-        b1_batch_stride,
-        e1_batch_stride,
-        in0_element_op,
-        wei0_element_op,
-        out0_element_op,
-        wei1_element_op,
-        out1_element_op);
+    auto argument  = device_op.MakeArgument(ck::auto_cast(in0_device_buf.GetDeviceBuffer()),
+                                           ck::auto_cast(wei0_device_buf.GetDeviceBuffer()),
+                                           ck::auto_cast(wei1_device_buf.GetDeviceBuffer()),
+                                           ck::auto_cast(out1_device_buf.GetDeviceBuffer()),
+                                           gemm0_m_length,
+                                           gemm0_n_length,
+                                           gemm0_k_length,
+                                           gemm1_n_length,
+                                           gemm_batch,
+                                           a0_stride,
+                                           b0_stride,
+                                           b1_stride,
+                                           e1_stride,
+                                           a0_batch_stride,
+                                           b0_batch_stride,
+                                           b1_batch_stride,
+                                           e1_batch_stride,
+                                           in0_element_op,
+                                           wei0_element_op,
+                                           out0_element_op,
+                                           wei1_element_op,
+                                           out1_element_op);
 
     if(!device_op.IsSupportedArgument(argument))
     {

--- a/library/include/ck/library/utility/auto_cast.hpp
+++ b/library/include/ck/library/utility/auto_cast.hpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace ck {
+
+template <typename T>
+struct AutoCastPtr
+{
+    using pointer = T*;
+
+    AutoCastPtr(const AutoCastPtr&) = default;
+    AutoCastPtr(AutoCastPtr&&)      = default;
+    ~AutoCastPtr()                  = default;
+    AutoCastPtr& operator=(const AutoCastPtr&) = default;
+    AutoCastPtr& operator=(AutoCastPtr&&) = default;
+
+    constexpr AutoCastPtr(pointer target = nullptr) noexcept : target_(target) {}
+
+    // avoid base-to-derived casting
+    template <
+        typename U,
+        typename = std::enable_if_t<
+            (std::is_same_v<U, void> || (std::is_same_v<U, const void> && std::is_const_v<T>)) ||
+            std::is_convertible_v<decltype(std::declval<AutoCastPtr<U>>().get()), pointer>>>
+    constexpr AutoCastPtr(AutoCastPtr<U> other) noexcept
+        : target_(static_cast<pointer>(other.get()))
+    {
+    }
+
+    constexpr pointer get() const noexcept { return target_; }
+
+    constexpr pointer operator->() const noexcept { return get(); }
+
+    constexpr std::add_lvalue_reference_t<T> operator*() const
+        noexcept(noexcept(*std::declval<pointer>()))
+    {
+        return *get();
+    }
+
+    template <typename U,
+              typename =
+                  std::enable_if_t<std::is_same_v<std::remove_const_t<T>, std::remove_const_t<U>> &&
+                                   (std::is_const_v<U> || !std::is_const_v<T>)>>
+    constexpr operator U*() const noexcept
+    {
+        return static_cast<U*>(get());
+    }
+
+    private:
+    pointer target_;
+};
+
+template <>
+struct AutoCastPtr<void>
+{
+    using pointer = void*;
+
+    AutoCastPtr(const AutoCastPtr&) = default;
+    AutoCastPtr(AutoCastPtr&&)      = default;
+    ~AutoCastPtr()                  = default;
+    AutoCastPtr& operator=(const AutoCastPtr&) = delete;
+    AutoCastPtr& operator=(AutoCastPtr&&) = default;
+
+    constexpr AutoCastPtr(pointer target = nullptr) noexcept : target_(target) {}
+
+    template <typename T, typename = std::enable_if_t<!std::is_const_v<T>>>
+    constexpr AutoCastPtr(T* target) noexcept : AutoCastPtr(target)
+    {
+    }
+
+    template <typename T, typename = std::enable_if_t<!std::is_const_v<T>>>
+    constexpr AutoCastPtr(AutoCastPtr<T> other) noexcept : target_(other.get())
+    {
+    }
+
+    constexpr pointer get() const noexcept { return target_; }
+
+    constexpr operator pointer() const noexcept { return get(); }
+
+    template <typename T>
+    constexpr operator T*() const noexcept
+    {
+        return static_cast<T*>(get());
+    }
+
+    private:
+    pointer target_;
+};
+
+template <>
+struct AutoCastPtr<const void>
+{
+    using pointer = const void*;
+
+    AutoCastPtr(const AutoCastPtr&) = default;
+    AutoCastPtr(AutoCastPtr&&)      = default;
+    ~AutoCastPtr()                  = default;
+    AutoCastPtr& operator=(const AutoCastPtr&) = default;
+    AutoCastPtr& operator=(AutoCastPtr&&) = default;
+
+    constexpr AutoCastPtr(pointer target = nullptr) noexcept : target_(target) {}
+
+    template <typename T>
+    constexpr AutoCastPtr(T* target) noexcept : AutoCastPtr(target)
+    {
+    }
+
+    template <typename T>
+    constexpr AutoCastPtr(AutoCastPtr<T> other) noexcept : target_(other.get())
+    {
+    }
+
+    constexpr pointer get() const noexcept { return target_; }
+
+    constexpr operator pointer() const noexcept { return get(); }
+
+    template <typename T, typename = std::enable_if_t<std::is_const_v<T>>>
+    constexpr operator T*() const noexcept
+    {
+        return static_cast<T*>(get());
+    }
+
+    private:
+    pointer target_;
+};
+
+inline constexpr struct auto_cast_function_type_
+{
+    explicit auto_cast_function_type_() = default;
+
+    template <typename T>
+    inline constexpr auto operator()(T* target) const
+        noexcept(std::is_nothrow_constructible_v<AutoCastPtr<T>, T*>)
+    {
+        return AutoCastPtr<T>(target);
+    }
+
+    inline constexpr auto operator()(std::nullptr_t) const
+        noexcept(std::is_nothrow_constructible_v<AutoCastPtr<void>>)
+    {
+        return AutoCastPtr<void>(nullptr);
+    }
+} auto_cast{};
+} // namespace ck

--- a/profiler/include/profile_batched_gemm_add_relu_gemm_add_impl.hpp
+++ b/profiler/include/profile_batched_gemm_add_relu_gemm_add_impl.hpp
@@ -10,6 +10,7 @@
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm_add_relu_gemm_add.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -267,12 +268,12 @@ bool profile_batched_gemm_add_relu_gemm_add_impl(bool do_verification,
     for(auto& op_ptr : op_ptrs)
     {
         auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<A0DataType*>(a0_g_m_k_device_buf.GetDeviceBuffer()),
-            static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
+            ck::auto_cast(a0_g_m_k_device_buf.GetDeviceBuffer()),
+            ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
             std::array<const void*, 1>{d0_g_m_n_device_buf.GetDeviceBuffer()},
-            static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
+            ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
             std::array<const void*, 1>{d1_g_m_o_device_buf.GetDeviceBuffer()},
-            static_cast<E1DataType*>(e1_g_m_o_device_buf.GetDeviceBuffer()),
+            ck::auto_cast(e1_g_m_o_device_buf.GetDeviceBuffer()),
             M,
             N,
             K,

--- a/profiler/include/profile_batched_gemm_gemm_impl.hpp
+++ b/profiler/include/profile_batched_gemm_gemm_impl.hpp
@@ -12,6 +12,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm_gemm.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -226,29 +227,29 @@ bool profile_batched_gemm_gemm_impl(bool do_verification,
     // profile device op instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-            static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-            static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-            static_cast<CDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-            M,
-            N,
-            K,
-            O,
-            BatchCount,
-            StrideA,
-            StrideB0,
-            StrideB1,
-            StrideC,
-            BatchStrideA,
-            BatchStrideB0,
-            BatchStrideB1,
-            BatchStrideC,
-            a_element_op,
-            b0_element_op,
-            acc0_element_op,
-            b1_element_op,
-            c_element_op);
+        auto argument_ptr =
+            op_ptr->MakeArgumentPointer(ck::auto_cast(a_g_m_k_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(c_g_m_o_device_buf.GetDeviceBuffer()),
+                                        M,
+                                        N,
+                                        K,
+                                        O,
+                                        BatchCount,
+                                        StrideA,
+                                        StrideB0,
+                                        StrideB1,
+                                        StrideC,
+                                        BatchStrideA,
+                                        BatchStrideB0,
+                                        BatchStrideB1,
+                                        BatchStrideC,
+                                        a_element_op,
+                                        b0_element_op,
+                                        acc0_element_op,
+                                        b1_element_op,
+                                        c_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 

--- a/profiler/include/profile_batched_gemm_impl.hpp
+++ b/profiler/include/profile_batched_gemm_impl.hpp
@@ -12,6 +12,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -148,9 +149,9 @@ bool profile_batched_gemm_impl(int do_verification,
     for(auto& op_ptr : op_ptrs)
     {
         auto argument_ptr =
-            op_ptr->MakeArgumentPointer(static_cast<ADataType*>(a_device_buf.GetDeviceBuffer()),
-                                        static_cast<BDataType*>(b_device_buf.GetDeviceBuffer()),
-                                        static_cast<CDataType*>(c_device_buf.GetDeviceBuffer()),
+            op_ptr->MakeArgumentPointer(ck::auto_cast(a_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(c_device_buf.GetDeviceBuffer()),
                                         M,
                                         N,
                                         K,

--- a/profiler/include/profile_batched_gemm_masking_scale_softmax_gemm_permute_impl.hpp
+++ b/profiler/include/profile_batched_gemm_masking_scale_softmax_gemm_permute_impl.hpp
@@ -12,6 +12,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm_masking_scale_softmax_gemm_permute.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -264,29 +265,29 @@ bool profile_batched_gemm_masking_scale_softmax_gemm_permute_impl(bool do_verifi
     // profile device op instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-            static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-            static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-            static_cast<CDataType*>(c_gs_ms_os_device_buf.GetDeviceBuffer()),
-            M,
-            N,
-            K,
-            O,
-            BatchCount,
-            c_gs_ms_os_lengths,
-            c_gs_ms_os_strides,
-            StrideA,
-            StrideB0,
-            StrideB1,
-            BatchStrideA,
-            BatchStrideB0,
-            BatchStrideB1,
-            a_element_op,
-            b0_element_op,
-            acc0_element_op,
-            b1_element_op,
-            c_element_op);
+        auto argument_ptr =
+            op_ptr->MakeArgumentPointer(ck::auto_cast(a_g_m_k_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(c_gs_ms_os_device_buf.GetDeviceBuffer()),
+                                        M,
+                                        N,
+                                        K,
+                                        O,
+                                        BatchCount,
+                                        c_gs_ms_os_lengths,
+                                        c_gs_ms_os_strides,
+                                        StrideA,
+                                        StrideB0,
+                                        StrideB1,
+                                        BatchStrideA,
+                                        BatchStrideB0,
+                                        BatchStrideB1,
+                                        a_element_op,
+                                        b0_element_op,
+                                        acc0_element_op,
+                                        b1_element_op,
+                                        c_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 

--- a/profiler/include/profile_batched_gemm_softmax_gemm_impl.hpp
+++ b/profiler/include/profile_batched_gemm_softmax_gemm_impl.hpp
@@ -12,6 +12,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/batched_gemm_softmax_gemm.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/profiler/include/profile_batched_gemm_softmax_gemm_impl.hpp
+++ b/profiler/include/profile_batched_gemm_softmax_gemm_impl.hpp
@@ -240,29 +240,29 @@ bool profile_batched_gemm_softmax_gemm_impl(bool do_verification,
     // profile device op instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<ADataType*>(a_g_m_k_device_buf.GetDeviceBuffer()),
-            static_cast<B0DataType*>(b0_g_k_n_device_buf.GetDeviceBuffer()),
-            static_cast<B1DataType*>(b1_g_n_o_device_buf.GetDeviceBuffer()),
-            static_cast<CDataType*>(c_g_m_o_device_buf.GetDeviceBuffer()),
-            M,
-            N,
-            K,
-            O,
-            BatchCount,
-            StrideA,
-            StrideB0,
-            StrideB1,
-            StrideC,
-            BatchStrideA,
-            BatchStrideB0,
-            BatchStrideB1,
-            BatchStrideC,
-            a_element_op,
-            b0_element_op,
-            acc0_element_op,
-            b1_element_op,
-            c_element_op);
+        auto argument_ptr =
+            op_ptr->MakeArgumentPointer(ck::auto_cast(a_g_m_k_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b0_g_k_n_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b1_g_n_o_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(c_g_m_o_device_buf.GetDeviceBuffer()),
+                                        M,
+                                        N,
+                                        K,
+                                        O,
+                                        BatchCount,
+                                        StrideA,
+                                        StrideB0,
+                                        StrideB1,
+                                        StrideC,
+                                        BatchStrideA,
+                                        BatchStrideB0,
+                                        BatchStrideB1,
+                                        BatchStrideC,
+                                        a_element_op,
+                                        b0_element_op,
+                                        acc0_element_op,
+                                        b1_element_op,
+                                        c_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 

--- a/profiler/include/profile_conv_bwd_data_impl.hpp
+++ b/profiler/include/profile_conv_bwd_data_impl.hpp
@@ -10,6 +10,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/convolution_backward_data.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -158,9 +159,9 @@ bool profile_conv_bwd_data_impl(int do_verification,
     for(auto& op_ptr : op_ptrs)
     {
         auto argument_ptr =
-            op_ptr->MakeArgumentPointer(static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-                                        static_cast<WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-                                        static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
+            op_ptr->MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(out_device_buf.GetDeviceBuffer()),
                                         conv_param.N_,
                                         conv_param.K_,
                                         conv_param.C_,

--- a/profiler/include/profile_conv_bwd_weight_impl.hpp
+++ b/profiler/include/profile_conv_bwd_weight_impl.hpp
@@ -15,6 +15,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/convolution_backward_weight.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -166,9 +167,9 @@ bool profile_conv_bwd_weight_impl(int do_verification,
     for(auto& op_ptr : op_ptrs)
     {
         auto argument_ptr =
-            op_ptr->MakeArgumentPointer(static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-                                        static_cast<WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-                                        static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
+            op_ptr->MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(out_device_buf.GetDeviceBuffer()),
                                         conv_param.N_,
                                         conv_param.K_,
                                         conv_param.C_,

--- a/profiler/include/profile_conv_fwd_bias_relu_add_impl.hpp
+++ b/profiler/include/profile_conv_fwd_bias_relu_add_impl.hpp
@@ -8,6 +8,7 @@
 #include "ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation_add.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -196,25 +197,25 @@ void profile_conv_fwd_bias_relu_add_impl(int do_verification,
     // profile device Conv instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<const InDataType*>(in_device_buf.GetDeviceBuffer()),
-            static_cast<const WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-            static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
-            static_cast<const OutDataType*>(bias_device_buf.GetDeviceBuffer()),
-            static_cast<const OutDataType*>(resi_device_buf.GetDeviceBuffer()),
-            N,
-            K,
-            C,
-            input_spatial_lengths,
-            filter_spatial_lengths,
-            output_spatial_lengths,
-            conv_filter_strides,
-            conv_filter_dilations,
-            input_left_pads,
-            input_right_pads,
-            in_element_op,
-            wei_element_op,
-            out_element_op);
+        auto argument_ptr =
+            op_ptr->MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(out_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(bias_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(resi_device_buf.GetDeviceBuffer()),
+                                        N,
+                                        K,
+                                        C,
+                                        input_spatial_lengths,
+                                        filter_spatial_lengths,
+                                        output_spatial_lengths,
+                                        conv_filter_strides,
+                                        conv_filter_dilations,
+                                        input_left_pads,
+                                        input_right_pads,
+                                        in_element_op,
+                                        wei_element_op,
+                                        out_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 

--- a/profiler/include/profile_conv_fwd_bias_relu_impl.hpp
+++ b/profiler/include/profile_conv_fwd_bias_relu_impl.hpp
@@ -8,6 +8,7 @@
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -186,24 +187,24 @@ void profile_conv_fwd_bias_relu_impl(int do_verification,
     // profile device Conv instances
     for(auto& op_ptr : op_ptrs)
     {
-        auto argument_ptr = op_ptr->MakeArgumentPointer(
-            static_cast<const InDataType*>(in_device_buf.GetDeviceBuffer()),
-            static_cast<const WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-            static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
-            static_cast<const OutDataType*>(bias_device_buf.GetDeviceBuffer()),
-            N,
-            K,
-            C,
-            input_spatial_lengths,
-            filter_spatial_lengths,
-            output_spatial_lengths,
-            conv_filter_strides,
-            conv_filter_dilations,
-            input_left_pads,
-            input_right_pads,
-            in_element_op,
-            wei_element_op,
-            out_element_op);
+        auto argument_ptr =
+            op_ptr->MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(out_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(bias_device_buf.GetDeviceBuffer()),
+                                        N,
+                                        K,
+                                        C,
+                                        input_spatial_lengths,
+                                        filter_spatial_lengths,
+                                        output_spatial_lengths,
+                                        conv_filter_strides,
+                                        conv_filter_dilations,
+                                        input_left_pads,
+                                        input_right_pads,
+                                        in_element_op,
+                                        wei_element_op,
+                                        out_element_op);
 
         auto invoker_ptr = op_ptr->MakeInvokerPointer();
 

--- a/profiler/include/profile_conv_fwd_impl.hpp
+++ b/profiler/include/profile_conv_fwd_impl.hpp
@@ -14,6 +14,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/convolution_forward.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -140,9 +141,9 @@ bool profile_conv_fwd_impl(int do_verification,
     for(auto& op_ptr : op_ptrs)
     {
         auto argument_ptr =
-            op_ptr->MakeArgumentPointer(static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-                                        static_cast<WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-                                        static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
+            op_ptr->MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(out_device_buf.GetDeviceBuffer()),
                                         conv_param.N_,
                                         conv_param.K_,
                                         conv_param.C_,

--- a/profiler/include/profile_convnd_bwd_data_impl.hpp
+++ b/profiler/include/profile_convnd_bwd_data_impl.hpp
@@ -8,6 +8,7 @@
 #include "ck/tensor_operation/gpu/device/device_conv_bwd_data.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/conv_util.hpp"
 #include "ck/library/host_tensor/device_memory.hpp"
@@ -391,23 +392,23 @@ bool profile_convnd_bwd_data_impl(int do_verification,
     bool success = true;
     for(auto& conv_ptr : conv_ptrs)
     {
-        auto argument_ptr = conv_ptr->MakeArgumentPointer(
-            static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-            static_cast<WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-            static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
-            N,
-            K,
-            C,
-            input_spatial_lengths,
-            filter_spatial_lengths,
-            output_spatial_lengths,
-            conv_filter_strides,
-            conv_filter_dilations,
-            input_left_pads,
-            input_right_pads,
-            in_element_op,
-            wei_element_op,
-            out_element_op);
+        auto argument_ptr =
+            conv_ptr->MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                          ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                          ck::auto_cast(out_device_buf.GetDeviceBuffer()),
+                                          N,
+                                          K,
+                                          C,
+                                          input_spatial_lengths,
+                                          filter_spatial_lengths,
+                                          output_spatial_lengths,
+                                          conv_filter_strides,
+                                          conv_filter_dilations,
+                                          input_left_pads,
+                                          input_right_pads,
+                                          in_element_op,
+                                          wei_element_op,
+                                          out_element_op);
 
         auto invoker_ptr = conv_ptr->MakeInvokerPointer();
 

--- a/profiler/include/profile_convnd_bwd_weight_impl.hpp
+++ b/profiler/include/profile_convnd_bwd_weight_impl.hpp
@@ -5,6 +5,7 @@
 #include "ck/tensor_operation/gpu/device/device_conv_backward_weight.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/conv_util.hpp"
 #include "ck/library/host_tensor/device_memory.hpp"
@@ -359,24 +360,24 @@ bool profile_convnd_bwd_weight_impl(int do_verification,
         //    wei_device_buf.SetZero();
         //}
 
-        auto argument_ptr = conv_ptr->MakeArgumentPointer(
-            static_cast<InDataType*>(in_device_buf.GetDeviceBuffer()),
-            static_cast<WeiDataType*>(wei_device_buf.GetDeviceBuffer()),
-            static_cast<OutDataType*>(out_device_buf.GetDeviceBuffer()),
-            N,
-            K,
-            C,
-            input_spatial_lengths,
-            filter_spatial_lengths,
-            output_spatial_lengths,
-            conv_filter_strides,
-            conv_filter_dilations,
-            input_left_pads,
-            input_right_pads,
-            in_element_op,
-            wei_element_op,
-            out_element_op,
-            split_k);
+        auto argument_ptr =
+            conv_ptr->MakeArgumentPointer(ck::auto_cast(in_device_buf.GetDeviceBuffer()),
+                                          ck::auto_cast(wei_device_buf.GetDeviceBuffer()),
+                                          ck::auto_cast(out_device_buf.GetDeviceBuffer()),
+                                          N,
+                                          K,
+                                          C,
+                                          input_spatial_lengths,
+                                          filter_spatial_lengths,
+                                          output_spatial_lengths,
+                                          conv_filter_strides,
+                                          conv_filter_dilations,
+                                          input_left_pads,
+                                          input_right_pads,
+                                          in_element_op,
+                                          wei_element_op,
+                                          out_element_op,
+                                          split_k);
 
         if(!conv_ptr->IsSupportedArgument(argument_ptr.get()))
         {

--- a/profiler/include/profile_gemm_impl.hpp
+++ b/profiler/include/profile_gemm_impl.hpp
@@ -14,6 +14,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/gemm.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -138,9 +139,9 @@ int profile_gemm_impl(int do_verification,
     for(auto& op_ptr : op_ptrs)
     {
         auto argument_ptr =
-            op_ptr->MakeArgumentPointer(static_cast<ADataType*>(a_device_buf.GetDeviceBuffer()),
-                                        static_cast<BDataType*>(b_device_buf.GetDeviceBuffer()),
-                                        static_cast<CDataType*>(c_device_buf.GetDeviceBuffer()),
+            op_ptr->MakeArgumentPointer(ck::auto_cast(a_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(c_device_buf.GetDeviceBuffer()),
                                         M,
                                         N,
                                         K,

--- a/profiler/include/profile_gemm_splitk_impl.hpp
+++ b/profiler/include/profile_gemm_splitk_impl.hpp
@@ -14,6 +14,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/gemm_splitk.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -140,9 +141,9 @@ bool profile_gemm_splitk_impl(int do_verification,
     for(auto& op_ptr : op_ptrs)
     {
         auto argument_ptr =
-            op_ptr->MakeArgumentPointer(static_cast<ADataType*>(a_device_buf.GetDeviceBuffer()),
-                                        static_cast<BDataType*>(b_device_buf.GetDeviceBuffer()),
-                                        static_cast<CDataType*>(c_device_buf.GetDeviceBuffer()),
+            op_ptr->MakeArgumentPointer(ck::auto_cast(a_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(b_device_buf.GetDeviceBuffer()),
+                                        ck::auto_cast(c_device_buf.GetDeviceBuffer()),
                                         M,
                                         N,
                                         K,

--- a/test/data_type/int4.cpp
+++ b/test/data_type/int4.cpp
@@ -12,6 +12,7 @@
 #include "ck/utility/data_type.hpp"
 #include "ck/utility/math_v2.hpp"
 #include "ck/utility/get_id.hpp"
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/device_memory.hpp"
 
 using ck::int4_t;
@@ -152,9 +153,8 @@ TEST(Int4, CopyAsI8NegativeValueStaticCast)
 
     d_src_i4.ToDevice(h_src_i4.data());
 
-    copy_with_static_cast<<<1, 64>>>(reinterpret_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
-                                     reinterpret_cast<std::int8_t*>(d_dst_i8.GetDeviceBuffer()),
-                                     SIZE);
+    copy_with_static_cast<<<1, 64>>>(
+        ck::auto_cast(d_src_i4.GetDeviceBuffer()), ck::auto_cast(d_dst_i8.GetDeviceBuffer()), SIZE);
     hip_check_error(hipDeviceSynchronize());
     d_dst_i8.FromDevice(h_dst_i8.data());
 

--- a/test/gemm/gemm_util.hpp
+++ b/test/gemm/gemm_util.hpp
@@ -5,6 +5,7 @@
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -77,9 +78,9 @@ bool RunDeviceGEMM(DeviceGemmPtr_& gemmPtr,
 
     auto invoker_ptr = gemmPtr->MakeInvokerPointer();
     auto argument_ptr =
-        gemmPtr->MakeArgumentPointer(static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
-                                     static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
-                                     static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
+        gemmPtr->MakeArgumentPointer(ck::auto_cast(a_m_k_device_buf.GetDeviceBuffer()),
+                                     ck::auto_cast(b_k_n_device_buf.GetDeviceBuffer()),
+                                     ck::auto_cast(c_m_n_device_buf.GetDeviceBuffer()),
                                      params.M,
                                      params.N,
                                      params.K,

--- a/test/gemm_split_k/gemm_split_k.cpp
+++ b/test/gemm_split_k/gemm_split_k.cpp
@@ -12,6 +12,7 @@
 
 #include "ck/library/tensor_operation_instance/gpu/gemm_splitk.hpp"
 
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
@@ -154,9 +155,9 @@ int test_gemm(const gemmArgs& args)
         for(auto& gemm_ptr : gemm_ptrs)
         {
             auto argument_ptr =
-                gemm_ptr->MakeArgumentPointer(static_cast<float*>(a_device_buf.GetDeviceBuffer()),
-                                              static_cast<float*>(b_device_buf.GetDeviceBuffer()),
-                                              static_cast<float*>(c_device_buf.GetDeviceBuffer()),
+                gemm_ptr->MakeArgumentPointer(ck::auto_cast(a_device_buf.GetDeviceBuffer()),
+                                              ck::auto_cast(b_device_buf.GetDeviceBuffer()),
+                                              ck::auto_cast(c_device_buf.GetDeviceBuffer()),
                                               args.M,
                                               args.N,
                                               args.K,

--- a/test/magic_number_division/magic_number_division.cpp
+++ b/test/magic_number_division/magic_number_division.cpp
@@ -8,6 +8,7 @@
 
 #include "ck/ck.hpp"
 #include "ck/utility/magic_division.hpp"
+#include "ck/library/utility/auto_cast.hpp"
 #include "ck/library/utility/check_err.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"

--- a/test/magic_number_division/magic_number_division.cpp
+++ b/test/magic_number_division/magic_number_division.cpp
@@ -91,11 +91,10 @@ int main(int, char*[])
     for(std::size_t i = 0; i < num_divisor; ++i)
     {
         // run naive division on GPU
-        gpu_naive_division<<<1024, 256>>>(
-            divisors_host[i],
-            static_cast<const int32_t*>(dividends_dev_buf.GetDeviceBuffer()),
-            static_cast<int32_t*>(naive_result_dev_buf.GetDeviceBuffer()),
-            num_dividend);
+        gpu_naive_division<<<1024, 256>>>(divisors_host[i],
+                                          ck::auto_cast(dividends_dev_buf.GetDeviceBuffer()),
+                                          ck::auto_cast(naive_result_dev_buf.GetDeviceBuffer()),
+                                          num_dividend);
 
         // calculate magic number
         uint32_t magic_multiplier, magic_shift;
@@ -107,8 +106,8 @@ int main(int, char*[])
         gpu_magic_number_division<<<1024, 256>>>(
             magic_multiplier,
             magic_shift,
-            static_cast<const int32_t*>(dividends_dev_buf.GetDeviceBuffer()),
-            static_cast<int32_t*>(magic_result_dev_buf.GetDeviceBuffer()),
+            ck::auto_cast(dividends_dev_buf.GetDeviceBuffer()),
+            ck::auto_cast(magic_result_dev_buf.GetDeviceBuffer()),
             num_dividend);
 
         naive_result_dev_buf.FromDevice(naive_result_host.data());


### PR DESCRIPTION
In the most of the `MakeArgument()` use cases, we pass the `DeviceMem::GetDeviceBuffer()` return value as argument to represent tensor starting address. However, we usually have to convert arguments from `void*` to whatever `MakeArgument()` takes. Those kinds of code strengthen dependency on device operator, once the author decide to alter the interface, we may have to update all the associated examples accordingly.

```c++
// file: example/01_gemm/run_gemm_example.inc
auto gemm     = DeviceGemmInstance{};
auto invoker  = gemm.MakeInvoker();
auto argument = gemm.MakeArgument(
#ifdef BUILD_INT4_EXAMPLE
	static_cast<KernelADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
	static_cast<KernelBDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
	static_cast<KernelCDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
#else
	static_cast<ADataType*>(a_m_k_device_buf.GetDeviceBuffer()),
	static_cast<BDataType*>(b_k_n_device_buf.GetDeviceBuffer()),
	static_cast<CDataType*>(c_m_n_device_buf.GetDeviceBuffer()),
#endif
	M,
	N,
	K,
	StrideA,
	StrideB,
	StrideC,
	a_element_op,
	b_element_op,
	c_element_op);
```

By leveraging template type argument deduction, we can let compiler to fill the destination type for us. 
Thus I introduced `ck::auto_cast()`, which returns a proxy `ck::AutoCastPtr<>` object. The `ck::AutoCastPtr<>` checks if desired conversion can be done only by `static_cast()`, and forbids _maybe-unsafe_ usages (e.g. convert pointer to base down to pointer to derived).

```c++
// file: example/01_gemm/run_gemm_example.inc (revised)
auto gemm     = DeviceGemmInstance{};
auto invoker  = gemm.MakeInvoker();
auto argument = gemm.MakeArgument(
	ck::auto_cast(a_m_k_device_buf.GetDeviceBuffer()),
	ck::auto_cast(b_k_n_device_buf.GetDeviceBuffer()),
	ck::auto_cast(c_m_n_device_buf.GetDeviceBuffer()),
	M,
	N,
	K,
	StrideA,
	StrideB,
	StrideC,
	a_element_op,
	b_element_op,
	c_element_op);
```

By implementing `ck::auto_cast()` as a functor, we can pass it to STL algorithms without worry about type arguments (also enabling use it as range adaptor in future).

```c++
constexpr std::size_t num_ints = 2;

// prepare memory for num_ints 'int' objects
std::array<std::byte, num_ints * sizeof(int)> bytes;
std::array<void*, num_ints> pvs{std::data(bytes), std::data(bytes) + sizeof(int)};

// generate corresponding pointers to each 'int' objects
std::array<int*, num_ints> pis;
std::ranges::transform(pvs, std::begin(pis), ck::auto_cast);
```