### PR TITLE
Fix build issues, set new compiler default, etc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,10 @@ ENV compiler_commit=$compiler_commit
 RUN sh -c "echo compiler version = '$compiler_version'"
 RUN sh -c "echo compiler commit = '$compiler_commit'"
 
+RUN --mount=type=ssh if [ "$compiler_version" = "amd-stg-open" ]; then \
+        sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl; \
+    fi
+
 RUN --mount=type=ssh if [ "$compiler_version" != "release" ] && [ "$compiler_commit" == "" ]; then \
         git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
         cd llvm-project && mkdir build && cd build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 
 ARG ROCMVERSION=5.2.3
 ARG compiler_version
+ARG compiler_commit
 
 RUN set -xe
 
@@ -12,7 +13,6 @@ RUN apt-get install -y wget gnupg
 RUN wget -qO - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
 RUN sh -c "echo deb [arch=amd64] $DEB_ROCM_REPO ubuntu main > /etc/apt/sources.list.d/rocm.list"
 RUN wget --no-check-certificate -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
-#RUN sh -c "echo deb https://apt.kitware.com/ubuntu/ bionic main | tee -a /etc/apt/sources.list"
 RUN sh -c "echo deb http://mirrors.kernel.org/ubuntu focal main universe | tee -a /etc/apt/sources.list"
 
 # Install dependencies
@@ -83,7 +83,9 @@ RUN sh -c "echo compiler version = '$compiler_version'"
 
 RUN --mount=type=ssh if [ "$compiler_version" != "release" ]; then \
         git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
-        cd llvm-project && mkdir build && cd build && \
+        cd llvm-project && \
+        if [ "$compiler_commit" != "" ]; then git checkout "$compiler_commit" && echo "checking out commit $compiler_commit"; \
+        mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm && \
         make -j 8 ; \
     else echo "using the release compiler"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ENV compiler_commit=$compiler_commit
 RUN sh -c "echo compiler version = '$compiler_version'"
 RUN sh -c "echo compiler commit = '$compiler_commit'"
 
-RUN --mount=type=ssh if [ "$compiler_version" != "release" && "$compiler_commit" == "" ]; then \
+RUN --mount=type=ssh if [[ "$compiler_version" -ne "release" && "$compiler_commit" -eq "" ]]; then \
         git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
         cd llvm-project && mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm && \
@@ -91,7 +91,7 @@ RUN --mount=type=ssh if [ "$compiler_version" != "release" && "$compiler_commit"
     else echo "using the release compiler"; \
     fi
 
-RUN --mount=type=ssh if [ "$compiler_version" != "release" && "$compiler_commit" != "" ]; then \
+RUN --mount=type=ssh if [[ "$compiler_version" -ne "release" && "$compiler_commit" -ne "" ]]; then \
         git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
         cd llvm-project && git checkout "$compiler_commit" && echo "checking out commit $compiler_commit" && mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ENV compiler_commit=$compiler_commit
 RUN sh -c "echo compiler version = '$compiler_version'"
 RUN sh -c "echo compiler commit = '$compiler_commit'"
 
-RUN --mount=type=ssh if [[ "$compiler_version" -ne "release" && "$compiler_commit" -eq "" ]]; then \
+RUN --mount=type=ssh if [ "$compiler_version" != "release" ] && [ "$compiler_commit" == "" ]; then \
         git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
         cd llvm-project && mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm && \
@@ -91,7 +91,7 @@ RUN --mount=type=ssh if [[ "$compiler_version" -ne "release" && "$compiler_commi
     else echo "using the release compiler"; \
     fi
 
-RUN --mount=type=ssh if [[ "$compiler_version" -ne "release" && "$compiler_commit" -ne "" ]]; then \
+RUN --mount=type=ssh if [ "$compiler_version" != "release" ] && [ "$compiler_commit" != "" ]; then \
         git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
         cd llvm-project && git checkout "$compiler_commit" && echo "checking out commit $compiler_commit" && mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ENV compiler_commit=$compiler_commit
 RUN sh -c "echo compiler version = '$compiler_version'"
 RUN sh -c "echo compiler commit = '$compiler_commit'"
 
-RUN --mount=type=ssh if [ "$compiler_version" = "amd-stg-open" ]; then \
+RUN --mount=type=ssh if [ "$compiler_version" == "amd-stg-open" ]; then \
         sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,11 +83,11 @@ ENV compiler_commit=$compiler_commit
 RUN sh -c "echo compiler version = '$compiler_version'"
 RUN sh -c "echo compiler commit = '$compiler_commit'"
 
-RUN --mount=type=ssh if [ "$compiler_version" == "amd-stg-open" ]; then \
+RUN --mount=type=ssh if [ "$compiler_version" = "amd-stg-open" ]; then \
         sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl; \
     fi
 
-RUN --mount=type=ssh if [ "$compiler_version" != "release" ] && [ "$compiler_commit" == "" ]; then \
+RUN --mount=type=ssh if [ "$compiler_version" != "release" ] && [ "$compiler_commit" = "" ]; then \
         git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
         cd llvm-project && mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,8 @@ RUN sh -c "echo compiler version = '$compiler_version'"
 RUN sh -c "echo compiler commit = '$compiler_commit'"
 
 RUN --mount=type=ssh if [ "$compiler_version" = "amd-stg-open" ]; then \
-        sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl; \
+        sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\    chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl && \
+        sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\    chomp($HIP_CLANG_TARGET);' /opt/rocm/bin/hipcc.pl; \
     fi
 
 RUN --mount=type=ssh if [ "$compiler_version" != "release" ] && [ "$compiler_commit" = "" ]; then \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ def runShell(String command){
 }
 
 def getDockerImageName(){
-    def img = "${env.CK_IMAGE_URL}:ck_ub20.04_rocm5.2.3_${params.COMPILER_VERSION}"
+    def img = "${env.CK_DOCKERHUB}:ck_ub20.04_rocm5.2.3_${params.COMPILER_VERSION}"
     return img
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -434,10 +434,6 @@ def Build_CK(Map conf=[:]){
         if (params.COMPILER_VERSION != "release"){
             dockerOpts = dockerOpts + " --env HIP_CLANG_PATH='/llvm-project/build/bin' "
         }
-        if (params.COMPILER_VERSION == "amd-stg-open"){
-            dockerOpts = dockerOpts + " --env CLANGRT_BUILTINS='/llvm-project/build/lib/clang/16.0.0/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a' "
-        }
-
 
         def variant = env.STAGE_NAME
         def retimage
@@ -592,7 +588,7 @@ pipeline {
             description: 'Specify which version of compiler to use: ck-9110, release, or amd-stg-open (default).')
         string(
             name: 'COMPILER_COMMIT', 
-            defaultValue: 'b0f4678b9058a4ae00200dfb1de0da5f2ea84dcb', 
+            defaultValue: '8a82e4eb7ba28521ba9a9424a0315a8a16590424', 
             description: 'Specify which commit of compiler branch to use: leave empty to use the latest commit, or use 10738 commit (default).')
         string(
             name: 'BUILD_COMPILER', 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -434,6 +434,10 @@ def Build_CK(Map conf=[:]){
         if (params.COMPILER_VERSION != "release"){
             dockerOpts = dockerOpts + " --env HIP_CLANG_PATH='/llvm-project/build/bin' "
         }
+        if (params.COMPILER_VERSION = "amd-stg-open"){
+            dockerOpts = dockerOpts + " --env CLANGRT_BUILTINS='/llvm-project/build/lib/clang/16.0.0/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a' "
+        }
+
 
         def variant = env.STAGE_NAME
         def retimage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -434,7 +434,7 @@ def Build_CK(Map conf=[:]){
         if (params.COMPILER_VERSION != "release"){
             dockerOpts = dockerOpts + " --env HIP_CLANG_PATH='/llvm-project/build/bin' "
         }
-        if (params.COMPILER_VERSION = "amd-stg-open"){
+        if (params.COMPILER_VERSION == "amd-stg-open"){
             dockerOpts = dockerOpts + " --env CLANGRT_BUILTINS='/llvm-project/build/lib/clang/16.0.0/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a' "
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -474,11 +474,6 @@ def Build_CK(Map conf=[:]){
             withDockerContainer(image: image, args: dockerOpts + ' -v=/var/jenkins/:/var/jenkins') {
                 timeout(time: 24, unit: 'HOURS')
                 {
-                    sh """
-                        if [ "${params.COMPILER_VERSION}" == "amd-stg-open" ]; then \
-                        sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\\chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl; \
-                        fi
-                    """
                     cmake_build(conf)
                     dir("build"){
                         //run tests and examples

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -476,7 +476,7 @@ def Build_CK(Map conf=[:]){
                 {
                     sh """
                         if [ "${params.COMPILER_VERSION}" == "amd-stg-open" ]; then \
-                        sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl; \
+                        sed -i '/$HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);/c\\chomp($HIP_CLANG_TARGET);' /opt/rocm/hip/bin/hipcc.pl; \
                         fi
                     """
                     cmake_build(conf)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 ROCmSoftwarePlatform/rocm-recipes
+RadeonOpenCompute/rocm-cmake@04f694df2a8dc9d7e35fa4dee4ba5fa407ec04f8 --build
 # 1.90+
+danmar/cppcheck@dd05839a7e63ef04afd34711cb3e1e0ef742882f


### PR DESCRIPTION
Several important changes:
1. Set the new default compiler (current latest version of branch amd-stg-open). This should fix all our compile and example errors.
2. Added a new build option to select a specific commit for compiler
3. Removed obsolete build option "Test Node", since now we can't run performance tests, bypassing all previous stages, since the ckProfiler is built in one of the first stages and then passed to the last stage
4. Moved the docker images from the amd repo to dockerhub. This should resolve connection issues and reduce push/pull times
5. Harmonized the dev-requirements.txt contents with MIOpen