### PR TITLE
fix missing -fPIC flag for conv3d_fwd instance lib

### DIFF
--- a/library/src/tensor_operation_instance/gpu/grouped_conv3d_fwd/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/grouped_conv3d_fwd/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(device_grouped_conv3d_fwd_instance
+add_instance_library(device_grouped_conv3d_fwd_instance
    device_grouped_conv3d_fwd_xdl_gndhwc_gkzyxc_gndhwk_bf16_instance.cpp
    device_grouped_conv3d_fwd_xdl_gndhwc_gkzyxc_gndhwk_f16_instance.cpp
    device_grouped_conv3d_fwd_xdl_gndhwc_gkzyxc_gndhwk_f32_instance.cpp


### PR DESCRIPTION
Internal user currently evaluating CK has met problems compiling as shared library. Diagnostic shows conv3d_fwd_instance is missing the -fPIC flag. 

```
ld.lld: error: relocation R_X86_64_32S cannot be used against symbol 'vtable for ck::tensor_operation::device::DeviceGroupedConvFwdMultipleD_Xdl_CShuffle<3, ck::tensor_layout::convolution::GNDHWC, ck::tensor_layout::convolution::GKZYXC, ck::Tuple<>, ck::tensor_layout::convolution::GNDHWK, unsigned short, unsigned short, float, unsigned short, ck::Tuple<>, unsigned short, ck::tensor_operation::element_wise::PassThrough, ck::tensor_operation::element_wise::PassThrough, ck::tensor_operation::element_wise::PassThrough, (ck::tensor_operation::device::ConvolutionForwardSpecialization)2, (ck::tensor_operation::device::GemmSpecialization)7, 1, 64, 32, 64, 32, 8, 8, 32, 32, 1, 2, ck::Sequence<4, 16, 1>, ck::Sequence<1, 0, 2>, ck::Sequence<1, 0, 2>, 2, 8, 8, 1, ck::Sequence<4, 16, 1>, ck::Sequence<1, 0, 2>, ck::Sequence<1, 0, 2>, 2, 8, 8, 1, 1, 1, ck::Sequence<1, 16, 1, 4>, 8, (ck::LoopScheduler)0>'; recompile with -fPIC
>>> defined in grouped_conv3d_fwd/CMakeFiles/device_grouped_conv3d_fwd_instance.dir/device_grouped_conv3d_fwd_xdl_gndhwc_gkzyxc_gndhwk_bf16_instance.cpp.o
>>> referenced by device_grouped_conv3d_fwd_xdl_gndhwc_gkzyxc_gndhwk_bf16_instance.cpp
```