### PR TITLE
Specify network setting while building docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ CK is released under the MIT license. [License File](/LICENSE)
 
 ## Build docker image
 ```bash
-DOCKER_BUILDKIT=1 docker build -t ck:latest -f Dockerfile .
+DOCKER_BUILDKIT=1 docker build --network=host -t ck:latest -f Dockerfile .
 ```
 
 ## Launch docker


### PR DESCRIPTION
The building docker container cannot connect to network on some host machines. Thus I added `--network=host` to `docker build` command explicitly to let it follow host network setting.