### PR TITLE
fix the script parsing the QA results

### DIFF
--- a/script/process_perf_data.py
+++ b/script/process_perf_data.py
@@ -81,7 +81,7 @@ def parse_logfile(logfile):
     StrideA=[]
     StrideB=[]
     StrideC=[]
-    if 'perf_gemm' in logfile:
+    if 'perf_gemm.log' in logfile:
         for line in open(logfile):
             if 'Best Perf' in line:
                 lst=line.split()
@@ -120,14 +120,14 @@ def parse_logfile(logfile):
         res = [x for _,x in sorted(zip(tests,tflops))]
         #sorted_kernels = [x for _,x in sorted(zip(tests,kernels))]
         test_list=list(range(1,len(tests)+1))
-    #parse conv_fwd performance tests:
-    elif 'conv_fwd' in logfile:
+    #parse conv_fwd and conv_bwd performance tests:
+    elif 'conv_fwd' in logfile or 'conv_bwd_data' in logfile:
         for line in open(logfile):
             if 'tflops:' in line:
                 lst=line.split()
                 res.append(lst[1])
     #parse all other performance tests:
-    elif 'resnet50' in logfile or 'batched_gemm' in logfile or 'grouped_gemm' in logfile or 'conv_bwd_data' in logfile or 'gemm_bilinear' in logfile or 'reduction' in logfile:
+    elif 'resnet50' in logfile or 'batched_gemm' in logfile or 'grouped_gemm' in logfile  or 'gemm_bilinear' in logfile or 'reduction' in logfile:
         for line in open(logfile):
             if 'Best Perf' in line:
                 lst=line.split()
@@ -149,7 +149,7 @@ def store_new_test_result(table_name, test_results, testlist, branch_name, node_
     df=pd.DataFrame(data=[params],columns=['Branch_ID','Node_ID','GPU_arch','Compute Units','ROCM_version','HIP_version','Environment','Datetime'])
     df_add=pd.DataFrame(data=[test_results],columns=testlist)
     df=pd.concat([df,df_add],axis=1)
-    print("new test results dataframe:",df)
+    #print("new test results dataframe:",df)
     df.to_sql(table_name,connection,if_exists='append',index=False)
     return 0
 
@@ -165,7 +165,7 @@ def compare_test_to_baseline(baseline,test,testlist):
                 print("test # ",i,"shows regression by {:.3f}%".format(
                     (float(test[i])-base_list[i])/base_list[i]*100))
                 regression=1
-            ave_perf=ave_perf+float(test[i])/base_list[i]
+            if base_list[i]>0: ave_perf=ave_perf+float(test[i])/base_list[i]
         if regression==0:
             print("no regressions found")
         ave_perf=ave_perf/len(base_list)
@@ -248,7 +248,7 @@ def main():
         conn = sqlEngine.connect()
 
         #save gemm performance tests:
-        if 'perf_gemm' in filename:
+        if 'perf_gemm.log' in filename:
             #write the ck_gemm_test_params table only needed once the test set changes
             #post_test_params(test_list,conn)
             for i in range(1,len(results)+1):


### PR DESCRIPTION
The python script processing the QA results was messing up the results for conv_bwd and gemm_bilinear kernels.

I have verified that the fix works correctly:

this is new row from the conv_bwd table:

'lwpck-474', 'hpe-sjc2-39', 'gfx90a', '104', '5.3.0', '5.3.22061-e8e78f1a', 'QA_release', '2022-10-26 07:05:44', '37.1707', '38.0164', '33.2186', '32.5096', '24.6142', '37.0726', '34.8511', '34.6174', '28.2624', '31.3456', '22.3235', '26.5103', '31.8428', '37.3862', '34.9756', '33.9038', '17.4158', '12.5944', '26.8995', '0', '93.6209', '119.044', '92.4938', '67.2132', '55.9901', '112.422', '104.379', '108.118', '72.628', '65.9462', '48.3366', '79.2362', '65.8616', '94.7894', '114.075', '110.304', '34.8068', '30.8174', '73.3233', '0', '88.0412', '112.222', '93.5699', '65.78', '57.061', '106.882', '101.049', '106.512', '72.3425', '57.9729', '35.8934', '77.2846', '56.8091', '89.7105', '111.062', '110.733', '34.2928', '27.0832', '80.9404', '0', '124.776', '137.294', '118.707', '113.973', '74.0602', '133.977', '129.861', '124.437', '86.3071', '106.512', '73.2174', '86.8032', '105.119', '127.277', '130.811', '124.078', '64.336', '49.6669', '100.74', '0'

and this is new row from the gemm_biliner table:

'lwpck-474', 'hpe-sjc2-39', 'gfx90a', '104', '5.3.0', '5.3.22061-e8e78f1a', 'QA_release', '2022-10-26 07:05:46', '49.5', '101.927', '122.758', '125.963', '52.5384', '105.772', '126.04', '127.75', '51.8672', '96.2279', '128.866', '133.453', '52.2046', '107.032', '131.004', '127.132', '51.7416', '107.611', '130.564', '137.382', '43.1218', '86.2363', '114.651', '121.949', '46.2268', '89.5583', '118.88', '123.43', '46.975', '90.0742', '123.199', '124.325', '52.0023', '97.5158', '128.66', '119.745', '49.8766', '96.0504', '127.512', '136.397', '47.4113', '102.551', '126.683', '132.733', '49.6367', '107.939', '129.727', '135.926', '47.4744', '98.9708', '126.028', '129.396', '48.5768', '108.35', '131.746', '128.798', '49.6735', '106.08', '131.784', '131.57', '44.1197', '101.567', '120.396', '131.455', '46.5518', '106.759', '124.343', '133.722', '46.503', '93.9322', '128.553', '130.355', '52.552', '108.251', '132.909', '136.792', '52.7585', '110.604', '129.349', '135.455'

