### PR TITLE
Fix CI error.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -619,8 +619,8 @@ pipeline {
                     agent{ label rocmnode("nogpu") }
                     environment{
                         execute_cmd = "find .. -not -path \'*.git*\' -iname \'*.h\' \
-                                -o -iname \'*.hpp\' \
-                                -o -iname \'*.cpp\' \
+                                -o -not -path \'*.git*\' -iname \'*.hpp\' \
+                                -o -not -path \'*.git*\' -iname \'*.cpp\' \
                                 -o -iname \'*.h.in\' \
                                 -o -iname \'*.hpp.in\' \
                                 -o -iname \'*.cpp.in\' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -618,7 +618,7 @@ pipeline {
                 stage('Clang Format') {
                     agent{ label rocmnode("nogpu") }
                     environment{
-                        execute_cmd = "find .. -iname \'*.h\' \
+                        execute_cmd = "find .. -not -path '.git/' -iname \'*.h\' \
                                 -o -iname \'*.hpp\' \
                                 -o -iname \'*.cpp\' \
                                 -o -iname \'*.h.in\' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -618,7 +618,7 @@ pipeline {
                 stage('Clang Format') {
                     agent{ label rocmnode("nogpu") }
                     environment{
-                        execute_cmd = "find .. -not -path '.git/' -iname \'*.h\' \
+                        execute_cmd = "find .. -not -path '*.git*' -iname \'*.h\' \
                                 -o -iname \'*.hpp\' \
                                 -o -iname \'*.cpp\' \
                                 -o -iname \'*.h.in\' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -618,7 +618,7 @@ pipeline {
                 stage('Clang Format') {
                     agent{ label rocmnode("nogpu") }
                     environment{
-                        execute_cmd = "find .. -not -path '*.git*' -iname \'*.h\' \
+                        execute_cmd = "find .. -not -path \'*.git*\' -iname \'*.h\' \
                                 -o -iname \'*.hpp\' \
                                 -o -iname \'*.cpp\' \
                                 -o -iname \'*.h.in\' \


### PR DESCRIPTION
The CI got broken when someone created a branch "modified_half_function_in_math_v2.hpp".
As a result, github created some files named "modified_half_function_in_math_v2.hpp" that were subsequently scanned by the clang-format script. The script, obviously, didn't find c++ code in those files, and caused the CI builds to crash.
I have added a filter for the most common file extensions ".h", ".hpp" and ".cpp" that will ignore any such files in the .git folder.