### PR TITLE
Remove circular includes

### DIFF
--- a/include/ck/utility/array_multi_index.hpp
+++ b/include/ck/utility/array_multi_index.hpp
@@ -4,8 +4,6 @@
 #ifndef CK_ARRAY_MULTI_INDEX_HPP
 #define CK_ARRAY_MULTI_INDEX_HPP
 
-#include "common_header.hpp"
-
 namespace ck {
 
 template <index_t N>

--- a/include/ck/utility/multi_index.hpp
+++ b/include/ck/utility/multi_index.hpp
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include "common_header.hpp"
-
 #if CK_EXPERIMENTAL_USE_DYNAMICALLY_INDEXED_MULTI_INDEX
 #include "array_multi_index.hpp"
 #else

--- a/include/ck/utility/statically_indexed_array_multi_index.hpp
+++ b/include/ck/utility/statically_indexed_array_multi_index.hpp
@@ -4,8 +4,6 @@
 #ifndef CK_STATICALLY_INDEXED_ARRAY_MULTI_INDEX_HPP
 #define CK_STATICALLY_INDEXED_ARRAY_MULTI_INDEX_HPP
 
-#include "common_header.hpp"
-
 namespace ck {
 
 template <index_t N>


### PR DESCRIPTION
PyTorch hipify does not support circular includes. Remove circular includes from relevant header files.