### PR TITLE
only run warm-up if timing is ON

### DIFF
--- a/example/20_grouped_conv_bwd_weight/run_grouped_conv_bwd_weight_example.inc
+++ b/example/20_grouped_conv_bwd_weight/run_grouped_conv_bwd_weight_example.inc
@@ -26,7 +26,7 @@ bool run_grouped_conv_bwd_weight(const ExecutionConfig& config,
     {
         split_k = 1;
     }
-    
+
     const auto in_g_n_c_wis_desc =
         ck::utils::conv::make_input_host_tensor_descriptor_g_n_c_wis_packed<
             InputLayout<NDimSpatial>>(conv_param);

--- a/include/ck/host_utility/kernel_launch.hpp
+++ b/include/ck/host_utility/kernel_launch.hpp
@@ -29,11 +29,15 @@ float launch_and_time_kernel(const StreamConfig& stream_config,
                block_dim.x,
                block_dim.y,
                block_dim.z);
-
-        printf("Warm up 1 time\n");
 #endif
-        // warm up
-        kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
+        if(stream_config.time_kernel_)
+        {
+#if DEBUG_LOG
+            printf("Warm up 1 time\n");
+#endif
+            // warm up
+            kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
+        }
 
         const int nrepeat = 10;
 #if DEBUG_LOG


### PR DESCRIPTION
Checked this with ckProfiler when the DEBUG_LOG=1: the warm=up only happens when the timing flag is ON.