### PR TITLE
[W/A] add gfx11 to GPU target avoid ROCm build issue

### DIFF
--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -30,8 +30,8 @@
 // check GPU target
 #ifdef __HIP_DEVICE_COMPILE__
 #if !(defined(__gfx803__) || defined(__gfx900__) || defined(__gfx906__) || defined(__gfx908__) || \
-      defined(__gfx90a__) || defined(__gfx1030__) || defined(__gfx1100__) || \
-      defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) )
+      defined(__gfx90a__) || defined(__gfx1030__) || defined(__gfx1100__) ||                      \
+      defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__))
 #error Not supported target
 #endif
 #endif
@@ -44,7 +44,7 @@
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x00020000
 #elif defined(__gfx1030__) // for GPU code
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x31014000
-#elif defined(__gfx1100__) || efined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) // for GPU code
+#elif defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) // for GPU code
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x10020000
 #endif
 

--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -30,7 +30,8 @@
 // check GPU target
 #ifdef __HIP_DEVICE_COMPILE__
 #if !(defined(__gfx803__) || defined(__gfx900__) || defined(__gfx906__) || defined(__gfx908__) || \
-      defined(__gfx90a__) || defined(__gfx1030__) || defined(__gfx1100__))
+      defined(__gfx90a__) || defined(__gfx1030__) || defined(__gfx1100__) || \
+      defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) )
 #error Not supported target
 #endif
 #endif
@@ -43,7 +44,7 @@
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x00020000
 #elif defined(__gfx1030__) // for GPU code
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x31014000
-#elif defined(__gfx1100__) // for GPU code
+#elif defined(__gfx1100__) || efined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) // for GPU code
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x10020000
 #endif
 


### PR DESCRIPTION
**[Clarification]**:
This is not to add `gfx11` to Composable Kernels' supported platform list. We simply workaround an issue with MIOpen build where GPU_TARGET env var is set as default on gfx11 platforms.

Since CK has its whitelist for runtime, this W/A should only impact build processes. Essentially NFC.

**[Discussion]**:
Composable Kernel needs to discuss how to support newly added ASICs.